### PR TITLE
[ENG-26010] Fix type handling for partition keys meta

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/util/SynthesizedColumnStrategy.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/util/SynthesizedColumnStrategy.java
@@ -1,12 +1,13 @@
 package io.trino.plugin.hudi.util;
 
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
 
 /**
  * Strategy interface for handling different types of synthesized columns
  */
 public interface SynthesizedColumnStrategy {
 
-    void appendToBlock(BlockBuilder blockBuilder);
+    void appendToBlock(BlockBuilder blockBuilder, Type type);
 
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
@@ -244,7 +244,7 @@ public class TpchHudiTablesInitializer
                 .withMarkersType(MarkerType.DIRECT.name())
                 // Disabling Hudi metadata table (MDT) in tests as the support of
                 // reading MDT is broken after removal of Hudi dependencies from compile time
-                .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).build())
+                .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(false).build())
                 .build();
         return new HoodieJavaWriteClient<>(new HoodieJavaEngineContext(new HadoopStorageConfiguration(conf)), cfg);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The root cause of `ClassCastException` is that the "synthesized" column strategy is hard‑coding all of the partition (and meta) columns to be written with
```
VarcharType.VARCHAR.writeSlice(…)
```
but the underlying `PageBuilder` was created from the  original columnHandles, and for, say, a DATE partition column, that slot in the page is actually backed by an `IntArrayBlockBuilder`, not a `VariableWidthBlockBuilder`. So when `VarcharType.writeSlice(...)` does
```
VariableWidthBlockBuilder vb = (VariableWidthBlockBuilder) blockBuilder;
```
you get:
```
ClassCastException: IntArrayBlockBuilder cannot be cast to VariableWidthBlockBuilder
```

To fix the issue, instead of always calling `VarcharType.VARCHAR.writeSlice`, we look up the real `Type` for that column and write the value in its native format (like we do for other fields).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
