### PR TITLE
Fix missing ClassNotFoundException aircompressor 

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -144,10 +144,6 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.airlift</groupId>
-                    <artifactId>aircompressor</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The error below is thrown when trying to reading RLI metadata hfiles.

This PR fixes it the class not found exception by adding aircompressor (non-v3) into trino-hudi's module.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

```shell
java.lang.NoClassDefFoundError: io/airlift/compress/hadoop/HadoopInputStream
	at org.apache.hudi.io.compress.HoodieDecompressorFactory.getDecompressor(HoodieDecompressorFactory.java:34)
	at org.apache.hudi.io.hfile.HFileContext.<init>(HFileContext.java:35)
	at org.apache.hudi.io.hfile.HFileContext.<init>(HFileContext.java:29)
	at org.apache.hudi.io.hfile.HFileContext$Builder.build(HFileContext.java:62)
	at org.apache.hudi.io.hfile.HFileReaderImpl.initializeMetadata(HFileReaderImpl.java:72)
	at org.apache.hudi.io.hfile.HFileReaderImpl.seekTo(HFileReaderImpl.java:183)
	at org.apache.hudi.io.storage.HoodieNativeAvroHFileReader$RecordIterator.hasNext(HoodieNativeAvroHFileReader.java:340)
	at org.apache.hudi.common.util.collection.MappingIterator.hasNext(MappingIterator.java:39)
	at org.apache.hudi.common.util.collection.MappingIterator.hasNext(MappingIterator.java:39)
	at org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner.processDataBlock(AbstractHoodieLogRecordScanner.java:633)
	at org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner.processQueuedBlocksForInstant(AbstractHoodieLogRecordScanner.java:675)
	at org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner.scanInternalV1(AbstractHoodieLogRecordScanner.java:378)
	at org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner.scanInternal(AbstractHoodieLogRecordScanner.java:250)
	at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner.performScan(HoodieMergedLogRecordScanner.java:204)
	at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner.<init>(HoodieMergedLogRecordScanner.java:120)
	at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner$Builder.build(HoodieMergedLogRecordScanner.java:481)
	at org.apache.hudi.metadata.HoodieMetadataLogRecordReader$Builder.build(HoodieMetadataLogRecordReader.java:247)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.getLogRecordScanner(HoodieBackedTableMetadata.java:669)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.openReaders(HoodieBackedTableMetadata.java:594)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.lambda$getOrCreateReaders$16(HoodieBackedTableMetadata.java:577)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1713)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.getOrCreateReaders(HoodieBackedTableMetadata.java:577)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.lookupKeysFromFileSlice(HoodieBackedTableMetadata.java:343)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.getRecordsByKeys(HoodieBackedTableMetadata.java:268)
	at org.apache.hudi.metadata.HoodieBackedTableMetadata.getRecordByKey(HoodieBackedTableMetadata.java:158)
	at org.apache.hudi.metadata.BaseTableMetadata.fetchAllPartitionPaths(BaseTableMetadata.java:343)
	at org.apache.hudi.metadata.BaseTableMetadata.getAllPartitionPaths(BaseTableMetadata.java:124)
	at org.apache.hudi.metadata.HoodieMetadataFileSystemView.getAllPartitionPaths(HoodieMetadataFileSystemView.java:72)
	at org.apache.hudi.common.table.view.AbstractTableFileSystemView.ensureAllPartitionsLoadedCorrectly(AbstractTableFileSystemView.java:348)
	at org.apache.hudi.common.table.view.AbstractTableFileSystemView.loadAllPartitions(AbstractTableFileSystemView.java:870)
	at io.trino.plugin.hudi.query.HudiSnapshotDirectoryLister.<init>(HudiSnapshotDirectoryLister.java:63)
	at io.trino.plugin.hudi.HudiSplitSource.<init>(HudiSplitSource.java:88)
	at io.trino.plugin.hudi.HudiSplitManager.getSplits(HudiSplitManager.java:101)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager.getSplits(ClassLoaderSafeConnectorSplitManager.java:51)
	at io.trino.split.SplitManager.getSplits(SplitManager.java:89)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.createSplitSource(SplitSourceFactory.java:183)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitFilter(SplitSourceFactory.java:254)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitFilter(SplitSourceFactory.java:130)
	at io.trino.sql.planner.plan.FilterNode.accept(FilterNode.java:74)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitOutput(SplitSourceFactory.java:360)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitOutput(SplitSourceFactory.java:130)
	at io.trino.sql.planner.plan.OutputNode.accept(OutputNode.java:82)
	at io.trino.sql.planner.SplitSourceFactory.createSplitSources(SplitSourceFactory.java:110)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.createStageScheduler(PipelinedQueryScheduler.java:1060)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.create(PipelinedQueryScheduler.java:935)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.createDistributedStagesScheduler(PipelinedQueryScheduler.java:324)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.start(PipelinedQueryScheduler.java:307)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:446)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:272)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1139)
	at io.trino.$gen.Trino_b3d9487____20250513_063509_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.ClassNotFoundException: io.airlift.compress.hadoop.HadoopInputStream
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:595)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:114)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:528)
	... 58 more
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
