### PR TITLE
Upgrade Hudi version to 1.0.2

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.hudi.version>1.0.1</dep.hudi.version>
+        <dep.hudi.version>1.0.2</dep.hudi.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiRecordLevelIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiRecordLevelIndexSupport.java
@@ -85,7 +85,7 @@ public class HudiRecordLevelIndexSupport
 
         // Perform index lookup in metadataTable
         // TODO: document here what this map is keyed by
-        Map<String, List<HoodieRecordGlobalLocation>> recordIndex = metadataTable.readRecordIndex(recordKeys);
+        Map<String, HoodieRecordGlobalLocation> recordIndex = metadataTable.readRecordIndex(recordKeys);
         if (recordIndex.isEmpty()) {
             log.debug("Record level index lookup returned no locations for the given keys.");
             // Return all original fileSlices
@@ -94,7 +94,6 @@ public class HudiRecordLevelIndexSupport
 
         // Collect fileIds for pruning
         Set<String> relevantFileIds = recordIndex.values().stream()
-                .flatMap(List::stream)
                 .map(HoodieRecordGlobalLocation::getFileId)
                 .collect(Collectors.toSet());
         log.debug(String.format("Record level index lookup identified %d relevant file IDs.", relevantFileIds.size()));

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiSecondaryIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiSecondaryIndexSupport.java
@@ -75,7 +75,7 @@ public class HudiSecondaryIndexSupport
 
         // Perform index lookup in metadataTable
         // TODO: document here what this map is keyed by
-        Map<String, List<HoodieRecordGlobalLocation>> recordKeyLocationsMap = metadataTable.readSecondaryIndex(secondaryKeys, indexName);
+        Map<String, HoodieRecordGlobalLocation> recordKeyLocationsMap = metadataTable.readSecondaryIndex(secondaryKeys, indexName);
         if (recordKeyLocationsMap.isEmpty()) {
             log.debug("Secondary index lookup returned no locations for the given keys.");
             // Return all original fileSlices
@@ -84,7 +84,6 @@ public class HudiSecondaryIndexSupport
 
         // Collect fileIds for pruning
         Set<String> relevantFileIds = recordKeyLocationsMap.values().stream()
-                .flatMap(List::stream)
                 .map(HoodieRecordGlobalLocation::getFileId)
                 .collect(Collectors.toSet());
         log.debug(String.format("Secondary index lookup identified %d relevant file IDs.", relevantFileIds.size()));

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/reader/HudiTrinoRecord.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/reader/HudiTrinoRecord.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.keygen.BaseKeyGenerator;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -57,7 +58,7 @@ public class HudiTrinoRecord
     }
 
     @Override
-    public Comparable<?> getOrderingValue(Schema schema, Properties properties)
+    public Comparable<?> doGetOrderingValue(Schema schema, Properties properties)
     {
         return null;
     }
@@ -168,6 +169,13 @@ public class HudiTrinoRecord
 
     @Override
     public Option<HoodieAvroIndexedRecord> toIndexedRecord(Schema schema, Properties properties)
+            throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public ByteArrayOutputStream getAvroBytes(Schema schema, Properties properties)
             throws IOException
     {
         return null;


### PR DESCRIPTION
## Description

This PR upgrades Hudi version to 1.0.2 for Hudi connector and fixes compilation issues.

## Additional context and related issues

[Hudi 1.0.2 release](https://hudi.apache.org/releases/release-1.0.2) fixes the backwards compatible reader for MDT among other fixes and improvements.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hudi Connector
* Upgrade Hudi version to 1.0.2
```
