### PR TITLE
[HUDI-9433] Return DataPageSource directly for splits that do not have log files

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiBaseFileOnlyPageSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiBaseFileOnlyPageSource.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hudi.util.SynthesizedColumnHandler;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class HudiBaseFileOnlyPageSource
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource physicalDataPageSource;
+    private final List<HiveColumnHandle> allOutputColumns;
+    private final SynthesizedColumnHandler synthesizedColumnHandler;
+    // Maps output channel to physical source channel, or -1 if synthesized
+    private final int[] physicalSourceChannelMap;
+
+    public HudiBaseFileOnlyPageSource(
+            ConnectorPageSource physicalDataPageSource,
+            List<HiveColumnHandle> allOutputColumns,
+            List<HiveColumnHandle> physicalDataColumns, // Columns provided by physicalDataPageSource
+            SynthesizedColumnHandler synthesizedColumnHandler)
+    {
+        this.physicalDataPageSource = requireNonNull(physicalDataPageSource, "physicalDataPageSource is null");
+        this.allOutputColumns = ImmutableList.copyOf(requireNonNull(allOutputColumns, "allOutputColumns is null"));
+        this.synthesizedColumnHandler = requireNonNull(synthesizedColumnHandler, "synthesizedColumnHandler is null");
+
+        // Create a mapping from the channel index in the output page to the channel index in the physicalDataPageSource's page
+        this.physicalSourceChannelMap = new int[allOutputColumns.size()];
+        Map<String, Integer> physicalColumnNameToChannel = new HashMap<>();
+        for (int i = 0; i < physicalDataColumns.size(); i++) {
+            physicalColumnNameToChannel.put(physicalDataColumns.get(i).getName().toLowerCase(Locale.ENGLISH), i);
+        }
+
+        for (int i = 0; i < allOutputColumns.size(); i++) {
+            this.physicalSourceChannelMap[i] = physicalColumnNameToChannel.getOrDefault(allOutputColumns.get(i).getName().toLowerCase(Locale.ENGLISH), -1);
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return physicalDataPageSource.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return physicalDataPageSource.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return physicalDataPageSource.isFinished();
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        SourcePage physicalSourcePage = physicalDataPageSource.getNextSourcePage();
+        if (physicalSourcePage == null) {
+            return null;
+        }
+
+        int positionCount = physicalSourcePage.getPositionCount();
+        if (positionCount == 0 && synthesizedColumnHandler.getSynthesizedColumnCount() == 0) {
+            // If only physical columns and page is empty
+            return physicalSourcePage;
+        }
+
+        Block[] outputBlocks = new Block[allOutputColumns.size()];
+        for (int i = 0; i < allOutputColumns.size(); i++) {
+            HiveColumnHandle outputColumn = allOutputColumns.get(i);
+            if (physicalSourceChannelMap[i] != -1) {
+                outputBlocks[i] = physicalSourcePage.getBlock(physicalSourceChannelMap[i]);
+            }
+            else {
+                // Column is synthesized
+                outputBlocks[i] = synthesizedColumnHandler.createRleSynthesizedBlock(outputColumn, positionCount);
+            }
+        }
+        return SourcePage.create(new Page(outputBlocks));
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return physicalDataPageSource.getMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        physicalDataPageSource.close();
+    }
+}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -73,7 +73,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -109,7 +108,7 @@ public class HudiPageSourceProvider
     private final TrinoFileSystemFactory fileSystemFactory;
     private final FileFormatDataSourceStats dataSourceStats;
     private final ParquetReaderOptions options;
-    private final DateTimeZone timeZone;
+    private final DateTimeZone timeZone = DateTimeZone.forID("UTC");
 
     @Inject
     public HudiPageSourceProvider(
@@ -120,7 +119,6 @@ public class HudiPageSourceProvider
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.dataSourceStats = requireNonNull(dataSourceStats, "dataSourceStats is null");
         this.options = requireNonNull(parquetReaderConfig, "parquetReaderConfig is null").toParquetReaderOptions();
-        this.timeZone = DateTimeZone.forID(TimeZone.getDefault().getID());
     }
 
     @Override
@@ -174,40 +172,52 @@ public class HudiPageSourceProvider
             // Unable to find table schema
             throw new TrinoException(HUDI_FILESYSTEM_ERROR, e);
         }
-        List<HiveColumnHandle> hiveColumns = columns.stream()
+
+        // Convert columns to HiveColumnHandles
+        List<HiveColumnHandle> hiveColumnHandles = columns.stream()
                 .map(HiveColumnHandle.class::cast)
                 .toList();
 
-        List<HiveColumnHandle> regularColumns = hiveColumns.stream()
+        // Get non-synthesized columns (columns that are available in data file)
+        List<HiveColumnHandle> nonSynthesizedColumnHandles = hiveColumnHandles.stream()
                 .filter(columnHandle -> !columnHandle.isPartitionKey() && !columnHandle.isHidden())
                 .collect(Collectors.toList());
-        List<HiveColumnHandle> columnHandles = prependHudiMetaColumns(regularColumns);
 
-        Schema requestedSchema = constructSchema(dataSchema, columnHandles.stream().map(HiveColumnHandle::getName).toList());
+        // The `columns` list could be empty when count(*) is issued, prepending hoodie meta columns allows a non-empty dataPageSource to be returned
+        List<HiveColumnHandle> nonSynthesizedWithHoodieMetaColumnHandles = prependHudiMetaColumns(nonSynthesizedColumnHandles);
 
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        // Only enable predicate pushdown for COW tables
-        boolean enablePredicatePushDown = ((HudiTableHandle) connectorTable).getTableType().equals(HoodieTableType.COPY_ON_WRITE);
+        // Enable predicate pushdown for splits containing only base files
+        boolean isBaseFileOnly = hudiSplit.getLogFiles().isEmpty();
         ConnectorPageSource dataPageSource = createPageSource(
                 session,
-                columnHandles,
+                nonSynthesizedWithHoodieMetaColumnHandles,
                 hudiSplit,
                 fileSystem.newInputFile(Location.of(hudiBaseFileOpt.get().getPath()), hudiBaseFileOpt.get().getFileSize()),
                 dataSourceStats,
                 options.withSmallFileThreshold(getParquetSmallFileThreshold(session))
                         .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session)),
-                timeZone, dynamicFilter, enablePredicatePushDown);
+                timeZone, dynamicFilter, isBaseFileOnly);
 
         SynthesizedColumnHandler synthesizedColumnHandler = SynthesizedColumnHandler.create(hudiSplit);
 
+        // Avoid avro serialization if split/filegroup only contains base files
+        if (isBaseFileOnly) {
+            return new HudiBaseFileOnlyPageSource(
+                    dataPageSource,
+                    hiveColumnHandles.isEmpty() ? nonSynthesizedWithHoodieMetaColumnHandles : hiveColumnHandles,
+                    nonSynthesizedWithHoodieMetaColumnHandles,
+                    synthesizedColumnHandler);
+        }
+
         HudiTrinoReaderContext readerContext = new HudiTrinoReaderContext(
                 dataPageSource,
-                hiveColumns.stream()
-                        .filter(columnHandle -> !columnHandle.isHidden())
-                        .collect(Collectors.toList()),
-                prependHudiMetaColumns(regularColumns),
+                nonSynthesizedColumnHandles,
+                nonSynthesizedWithHoodieMetaColumnHandles,
                 synthesizedColumnHandler);
 
+        // Construct an Avro schema for log file reader
+        Schema requestedSchema = constructSchema(dataSchema, nonSynthesizedWithHoodieMetaColumnHandles.stream().map(HiveColumnHandle::getName).toList());
         HoodieFileGroupReader<IndexedRecord> fileGroupReader =
                 new HoodieFileGroupReader<>(
                         readerContext,
@@ -228,7 +238,7 @@ public class HudiPageSourceProvider
                 dataPageSource,
                 fileGroupReader,
                 readerContext,
-                hiveColumns,
+                hiveColumnHandles,
                 synthesizedColumnHandler);
     }
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -804,6 +804,7 @@ public class TestHudiSmokeTest
             MaterializedResult actualResults = getQueryRunner().execute(session, actualQuery);
             MaterializedResult expectedResults = getQueryRunner().execute(session, expectedQuery);
             assertThat(actualResults.getMaterializedRows())
+                    .describedAs("failedQuery: " + actualQuery)
                     .hasSameSizeAs(expectedResults.getMaterializedRows())
                     .containsAll(expectedResults.getMaterializedRows());
         }

--- a/plugin/trino-hudi/src/test/resources/hudi-testing-data/hudi_multi_fg_pt_mor/README.md
+++ b/plugin/trino-hudi/src/test/resources/hudi-testing-data/hudi_multi_fg_pt_mor/README.md
@@ -53,4 +53,4 @@ test("Create table multi filegroup partitioned mor") {
 - For test cases that require column stats index
 - For test cases that require partition stats index
 - For test cases that require record level index
-- FOr test cases that require secondary index
+- For test cases that require secondary index


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If table is of type COW or MOR read_optimized, we can return a datapage source directly and avoid HudiAvroserializer altogether.

for filegroups that have no log files, we can do perform a predicate pushdown too.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
