### PR TITLE
[HUDI-9492] Add table statistics support in Trino Hudi connector

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -380,6 +380,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20250107</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -38,6 +38,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class HudiConfig
 {
     private List<String> columnsToHide = ImmutableList.of();
+    private boolean tableStatisticsEnabled = true;
+    private int tableStatisticsExecutorParallelism = 4;
     private boolean metadataEnabled;
     private boolean shouldUseParquetColumnNames = true;
     private boolean sizeBasedSplitWeightsEnabled = true;
@@ -71,6 +73,33 @@ public class HudiConfig
         this.columnsToHide = columnsToHide.stream()
                 .map(s -> s.toLowerCase(ENGLISH))
                 .collect(toImmutableList());
+        return this;
+    }
+
+    @Config("hudi.table-statistics-enabled")
+    @ConfigDescription("Enable table statistics for query planning.")
+    public HudiConfig setTableStatisticsEnabled(boolean tableStatisticsEnabled)
+    {
+        this.tableStatisticsEnabled = tableStatisticsEnabled;
+        return this;
+    }
+
+    public boolean isTableStatisticsEnabled()
+    {
+        return this.tableStatisticsEnabled;
+    }
+
+    @Min(1)
+    public int getTableStatisticsExecutorParallelism()
+    {
+        return tableStatisticsExecutorParallelism;
+    }
+
+    @Config("hudi.table-statistics-executor-parallelism")
+    @ConfigDescription("Number of threads to asynchronously generate table statistics.")
+    public HudiConfig setTableStatisticsExecutorParallelism(int parallelism)
+    {
+        this.tableStatisticsExecutorParallelism = parallelism;
         return this;
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -44,6 +44,7 @@ public class HudiSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String COLUMNS_TO_HIDE = "columns_to_hide";
+    static final String TABLE_STATISTICS_ENABLED = "table_statistics_enabled";
     static final String METADATA_TABLE_ENABLED = "metadata_enabled";
     private static final String USE_PARQUET_COLUMN_NAMES = "use_parquet_column_names";
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
@@ -81,6 +82,11 @@ public class HudiSessionProperties
                                 .map(name -> ((String) name).toLowerCase(ENGLISH))
                                 .collect(toImmutableList()),
                         value -> value),
+                booleanProperty(
+                        TABLE_STATISTICS_ENABLED,
+                        "Expose table statistics",
+                        hudiConfig.isTableStatisticsEnabled(),
+                        false),
                 booleanProperty(
                         METADATA_TABLE_ENABLED,
                         "For Hudi tables prefer to fetch the list of files from its metadata table",
@@ -184,6 +190,11 @@ public class HudiSessionProperties
     public static List<String> getColumnsToHide(ConnectorSession session)
     {
         return (List<String>) session.getProperty(COLUMNS_TO_HIDE, List.class);
+    }
+
+    public static boolean isTableStatisticsEnabled(ConnectorSession session)
+    {
+        return session.getProperty(TABLE_STATISTICS_ENABLED, Boolean.class);
     }
 
     public static boolean isHudiMetadataTableEnabled(ConnectorSession session)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/ForHudiTableStatistics.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/ForHudiTableStatistics.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.stats;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForHudiTableStatistics {}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/HudiTableStatistics.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/HudiTableStatistics.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.stats;
+
+import io.trino.spi.statistics.TableStatistics;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+
+public record HudiTableStatistics(
+        HoodieInstant latestCommit,
+        TableStatistics tableStatistics)
+{
+}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/TableMetadataReader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/TableMetadataReader.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.stats;
+
+import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieMetadataMetrics;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.storage.HoodieStorage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Reads metadata efficiently from a Hudi metadata table.
+ */
+public class TableMetadataReader
+        extends HoodieBackedTableMetadata
+{
+    TableMetadataReader(HoodieEngineContext engineContext, HoodieStorage storage,
+                               HoodieMetadataConfig metadataConfig, String datasetBasePath, boolean reuse)
+    {
+        super(engineContext, storage, metadataConfig, datasetBasePath, reuse);
+    }
+
+    /**
+     * Retrieves column statistics for the specified partition and file names.
+     *
+     * @param partitionNameFileNameList a list of partition and file name pairs for which column statistics are retrieved
+     * @param columnNames a list of column names for which statistics are needed
+     * @return a map from column name to their corresponding {@link HoodieColumnRangeMetadata}
+     * @throws HoodieMetadataException if an error occurs while fetching the column statistics
+     */
+    Map<String, HoodieColumnRangeMetadata> getColumnStats(List<Pair<String, String>> partitionNameFileNameList, List<String> columnNames)
+            throws HoodieMetadataException
+    {
+        return computeFileToColumnStatsMap(computeColumnStatsLookupKeys(partitionNameFileNameList, columnNames));
+    }
+
+    /**
+     * @param partitionNameFileNameList a list of partition and file name pairs for which column stats need to be retrieved
+     * @param columnNames list of column names for which stats are needed
+     * @return a list of column stats keys to look up in the metadata table col_stats partition.
+     */
+    private List<String> computeColumnStatsLookupKeys(
+            final List<Pair<String, String>> partitionNameFileNameList,
+            final List<String> columnNames)
+    {
+        return columnNames.stream()
+                .flatMap(columnName -> partitionNameFileNameList.stream()
+                        .map(partitionNameFileNamePair -> HoodieMetadataPayload.getColumnStatsIndexKey(
+                                new PartitionIndexID(HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partitionNameFileNamePair.getLeft())),
+                                new FileIndexID(partitionNameFileNamePair.getRight()),
+                                new ColumnIndexID(columnName))))
+                .toList();
+    }
+
+    /**
+     * @param columnStatsLookupKeys a map from column stats key to partition and file name pair
+     * @return a map from column name to merged HoodieMetadataColumnStats
+     */
+    private Map<String, HoodieColumnRangeMetadata> computeFileToColumnStatsMap(List<String> columnStatsLookupKeys)
+    {
+        HoodieTimer timer = HoodieTimer.start();
+        Map<String, HoodieRecord<HoodieMetadataPayload>> hoodieRecords =
+                getRecordsByKeys(columnStatsLookupKeys, MetadataPartitionType.COLUMN_STATS.getPartitionPath());
+        metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_COLUMN_STATS_METADATA_STR, timer.endTimer()));
+        return hoodieRecords.values().stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getData().getColumnStatMetadata().get().getColumnName(),
+                        Collectors.mapping(r -> r.getData().getColumnStatMetadata().get(), Collectors.toList())))
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> {
+                            long valueCount = 0L;
+                            long nullCount = 0L;
+                            long totalSize = 0L;
+                            long totalUncompressedSize = 0L;
+                            for (HoodieMetadataColumnStats stats : e.getValue()) {
+                                valueCount += stats.getValueCount();
+                                nullCount += stats.getNullCount();
+                                totalSize += stats.getTotalSize();
+                                totalUncompressedSize += stats.getTotalUncompressedSize();
+                            }
+                            return HoodieColumnRangeMetadata.create(
+                                    "", e.getKey(), null, null, nullCount, valueCount, totalSize, totalUncompressedSize);
+                        }));
+    }
+}

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/TableStatisticsReader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/stats/TableStatisticsReader.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.stats;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hudi.storage.TrinoStorageConfiguration;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.statistics.ColumnStatistics;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.collection.Pair;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads table statistics of a Hudi table from the metadata table files and column stats partitions.
+ */
+public class TableStatisticsReader
+{
+    private static final Logger log = Logger.get(TableStatisticsReader.class);
+    private final HoodieTableMetaClient metaClient;
+    private final TableMetadataReader tableMetadata;
+    private final HoodieTableFileSystemView fileSystemView;
+
+    private TableStatisticsReader(HoodieTableMetaClient metaClient)
+    {
+        this.metaClient = metaClient;
+        HoodieEngineContext engineContext = new HoodieLocalEngineContext(new TrinoStorageConfiguration());
+        HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+        this.tableMetadata = new TableMetadataReader(
+                engineContext, metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
+        this.fileSystemView = new HoodieTableFileSystemView(tableMetadata, metaClient,
+                metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+    }
+
+    public static TableStatisticsReader create(HoodieTableMetaClient metaClient)
+    {
+        return new TableStatisticsReader(metaClient);
+    }
+
+    /**
+     * Retrieves table statistics of a Hudi table based on the latest commit and specified columns.
+     *
+     * @param latestCommit the most recent commit at which to retrieve the statistics
+     * @param columnHandles a list of {@link HiveColumnHandle} representing the columns for which statistics are needed
+     * @return {@link TableStatistics} object containing the statistics of the specified columns, or empty statistics if unable to retrieve
+     */
+    public TableStatistics getTableStatistics(HoodieInstant latestCommit,
+                                              List<HiveColumnHandle> columnHandles)
+    {
+        List<String> columnNames = columnHandles.stream()
+                .map(HiveColumnHandle::getName)
+                .toList();
+        Map<String, HoodieColumnRangeMetadata> columnStatsMap = getColumnStats(latestCommit, tableMetadata, fileSystemView, columnNames);
+        if (columnStatsMap.isEmpty()) {
+            log.warn("Unable to get column stats from metadata table for table, returning empty table statistics: %s",
+                    metaClient.getBasePath());
+            return TableStatistics.empty();
+        }
+        long rowCount = columnStatsMap.values().stream()
+                .map(e -> e.getNullCount() + e.getValueCount())
+                .max(Long::compare)
+                .get();
+        ImmutableMap.Builder<ColumnHandle, ColumnStatistics> columnHandleBuilder = ImmutableMap.builder();
+        for (HiveColumnHandle columnHandle : columnHandles) {
+            HoodieColumnRangeMetadata columnStats = columnStatsMap.get(columnHandle.getName());
+            if (columnStats == null) {
+                log.warn("Unable to get column stats for column %s in table %s",
+                        columnHandle.getName(), metaClient.getBasePath());
+                continue;
+            }
+            ColumnStatistics.Builder columnStatisticsBuilder = new ColumnStatistics.Builder();
+            long totalCount = columnStats.getNullCount() + columnStats.getValueCount();
+            columnStatisticsBuilder.setNullsFraction(Estimate.of(
+                    columnStats.getNullCount() / (double) totalCount));
+            columnStatisticsBuilder.setDataSize(Estimate.of(columnStats.getTotalUncompressedSize() / (double) totalCount));
+            columnHandleBuilder.put(columnHandle, columnStatisticsBuilder.build());
+        }
+        return new TableStatistics(Estimate.of(rowCount), columnHandleBuilder.buildOrThrow());
+    }
+
+    private static Map<String, HoodieColumnRangeMetadata> getColumnStats(
+            HoodieInstant latestCommit,
+            TableMetadataReader tableMetadata,
+            HoodieTableFileSystemView fileSystemView,
+            List<String> columnNames)
+    {
+        fileSystemView.loadAllPartitions();
+        List<Pair<String, String>> filePaths = fileSystemView.getAllLatestBaseFilesBeforeOrOn(latestCommit.requestedTime())
+                .entrySet()
+                .stream().flatMap(entry -> entry.getValue()
+                        .map(baseFile -> Pair.of(entry.getKey(), baseFile.getFileName())))
+                .toList();
+        return tableMetadata.getColumnStats(filePaths, columnNames);
+    }
+}

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/SessionBuilder.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/SessionBuilder.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hudi;
 import io.trino.Session;
 
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.hudi.HudiSessionProperties.COLUMN_STATS_INDEX_ENABLED;
 import static io.trino.plugin.hudi.HudiSessionProperties.DYNAMIC_FILTERING_WAIT_TIMEOUT;
 import static io.trino.plugin.hudi.HudiSessionProperties.METADATA_TABLE_ENABLED;
@@ -23,6 +24,7 @@ import static io.trino.plugin.hudi.HudiSessionProperties.PARTITION_STATS_INDEX_E
 import static io.trino.plugin.hudi.HudiSessionProperties.QUERY_PARTITION_FILTER_REQUIRED;
 import static io.trino.plugin.hudi.HudiSessionProperties.RECORD_LEVEL_INDEX_ENABLED;
 import static io.trino.plugin.hudi.HudiSessionProperties.SECONDARY_INDEX_ENABLED;
+import static io.trino.plugin.hudi.HudiSessionProperties.TABLE_STATISTICS_ENABLED;
 import static java.util.Objects.requireNonNull;
 
 public class SessionBuilder
@@ -71,9 +73,19 @@ public class SessionBuilder
         return this.sessionBuilder.build();
     }
 
+    public SessionBuilder withJoinDistributionType(String joinDistributionType)
+    {
+        return setSystemProperty(JOIN_DISTRIBUTION_TYPE, joinDistributionType);
+    }
+
     public SessionBuilder withPartitionFilterRequired(boolean required)
     {
         return setCatalogProperty(QUERY_PARTITION_FILTER_REQUIRED, String.valueOf(required));
+    }
+
+    public SessionBuilder withTableStatisticsEnabled(boolean enabled)
+    {
+        return setCatalogProperty(TABLE_STATISTICS_ENABLED, String.valueOf(enabled));
     }
 
     public SessionBuilder withMdtEnabled(boolean enabled)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -33,8 +33,10 @@ public class TestHudiConfig
     {
         assertRecordedDefaults(recordDefaults(HudiConfig.class)
                 .setColumnsToHide(ImmutableList.of())
+                .setTableStatisticsEnabled(true)
                 .setMetadataEnabled(false)
                 .setUseParquetColumnNames(true)
+                .setTableStatisticsExecutorParallelism(4)
                 .setSizeBasedSplitWeightsEnabled(true)
                 .setStandardSplitWeightSize(DataSize.of(128, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.05)
@@ -57,8 +59,10 @@ public class TestHudiConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("hudi.columns-to-hide", "_hoodie_record_key")
+                .put("hudi.table-statistics-enabled", "false")
                 .put("hudi.metadata-enabled", "true")
                 .put("hudi.parquet.use-column-names", "false")
+                .put("hudi.table-statistics-executor-parallelism", "16")
                 .put("hudi.size-based-split-weights-enabled", "false")
                 .put("hudi.standard-split-weight-size", "64MB")
                 .put("hudi.minimum-assigned-split-weight", "0.1")
@@ -78,8 +82,10 @@ public class TestHudiConfig
 
         HudiConfig expected = new HudiConfig()
                 .setColumnsToHide(ImmutableList.of("_hoodie_record_key"))
+                .setTableStatisticsEnabled(false)
                 .setMetadataEnabled(true)
                 .setUseParquetColumnNames(false)
+                .setTableStatisticsExecutorParallelism(16)
                 .setSizeBasedSplitWeightsEnabled(false)
                 .setStandardSplitWeightSize(DataSize.of(64, MEGABYTE))
                 .setMinimumAssignedSplitWeight(0.1)


### PR DESCRIPTION
## Description

This PR adds table statistics support in Trino Hudi connector.

## Additional context and related issues

This PR adds a table statistics cache in Trino Hudi connector and the logic to fetch table statistics from the cache based on the table base path for query planning and optimization.  If the table statistics are not available, empty table statistics are returned. Whenever the table statistics are fetched, an async stats refresh execution is triggered to get the new table stats based on the latest commit, if that has changed, so that the table statistics generation does not block the query planning.

Two new connector configs and one session property are added:
- Connector configs:
  - `hudi.table-statistics-enabled`: enables table statistics for query planning.
  - `hudi.table-statistics-executor-parallelism`: number of threads to asynchronously generate table statistics.
- Session property:
  - `hudi.table_statistics_enabled`: whether to enable table statistics. When `false`, async stats refresh is turned off.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hudi Connector
* Adds table statistics support for CBO
```
