### PR TITLE
[HUDI-9498] Use batch call to get partition information from the metastore

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -14,13 +14,17 @@
 package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.Partition;
+import io.trino.metastore.StorageFormat;
 import io.trino.metastore.Table;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveTransactionHandle;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -34,6 +38,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
@@ -42,11 +47,13 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.computePartitionKeyFilter;
 import static io.trino.plugin.hive.util.HiveUtil.getPartitionKeyColumnHandles;
+import static io.trino.plugin.hudi.HudiErrorCode.HUDI_PARTITION_NOT_FOUND;
 import static io.trino.plugin.hudi.HudiSessionProperties.getDynamicFilteringWaitTimeout;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxOutstandingSplits;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxSplitsPerSecond;
 import static io.trino.plugin.hudi.partition.HiveHudiPartitionInfo.NON_PARTITION;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
@@ -90,11 +97,10 @@ public class HudiSplitManager
         List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table, typeManager);
         Map<String, HiveColumnHandle> partitionColumnHandles = partitionColumns.stream()
                 .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
-        List<String> allPartitions = getPartitions(metastore, hudiTableHandle, partitionColumns);
+        Map<String, Partition> allPartitions = getPartitions(metastore, hudiTableHandle, table, partitionColumns);
 
         HudiSplitSource splitSource = new HudiSplitSource(
                 session,
-                metastore,
                 table,
                 hudiTableHandle,
                 fileSystemFactory,
@@ -109,17 +115,39 @@ public class HudiSplitManager
         return new ClassLoaderSafeConnectorSplitSource(splitSource, HudiSplitManager.class.getClassLoader());
     }
 
-    private static List<String> getPartitions(HiveMetastore metastore, HudiTableHandle table, List<HiveColumnHandle> partitionColumns)
+    private static Map<String, Partition> getPartitions(
+            HiveMetastore metastore,
+            HudiTableHandle tableHandle,
+            Table table,
+            List<HiveColumnHandle> partitionColumns)
     {
         if (partitionColumns.isEmpty()) {
-            return ImmutableList.of(NON_PARTITION);
+            return ImmutableMap.of(
+                    NON_PARTITION, Partition.builder()
+                            .setDatabaseName(tableHandle.getSchemaName())
+                            .setTableName(tableHandle.getTableName())
+                            .withStorage(storageBuilder ->
+                                    storageBuilder.setLocation(tableHandle.getBasePath())
+                                            .setStorageFormat(StorageFormat.NULL_STORAGE_FORMAT))
+                            .setColumns(ImmutableList.of())
+                            .setValues(ImmutableList.of())
+                            .build());
         }
 
-        return metastore.getPartitionNamesByFilter(
-                        table.getSchemaName(),
-                        table.getTableName(),
+        List<String> partitionNames = metastore.getPartitionNamesByFilter(
+                        tableHandle.getSchemaName(),
+                        tableHandle.getTableName(),
                         partitionColumns.stream().map(HiveColumnHandle::getName).collect(Collectors.toList()),
-                        computePartitionKeyFilter(partitionColumns, table.getPartitionPredicates()))
-                .orElseThrow(() -> new TableNotFoundException(table.getSchemaTableName()));
+                        computePartitionKeyFilter(partitionColumns, tableHandle.getPartitionPredicates()))
+                .orElseThrow(() -> new TableNotFoundException(tableHandle.getSchemaTableName()));
+        Map<String, Optional<Partition>> partitionsByNames = metastore.getPartitionsByNames(table, partitionNames);
+        List<String> partitionsNotFound = partitionsByNames.entrySet().stream().filter(e -> e.getValue().isEmpty()).map(Map.Entry::getKey).toList();
+        if (!partitionsNotFound.isEmpty()) {
+            throw new TrinoException(HUDI_PARTITION_NOT_FOUND, format("Cannot find partitions in metastore: %s", partitionsNotFound));
+        }
+        return partitionsByNames
+                .entrySet().stream()
+                .filter(e -> e.getValue().isPresent())
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get()));
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -20,7 +20,7 @@ import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.Partition;
 import io.trino.metastore.Table;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
@@ -82,7 +82,6 @@ public class HudiSplitSource
 
     public HudiSplitSource(
             ConnectorSession session,
-            HiveMetastore metastore,
             Table table,
             HudiTableHandle tableHandle,
             TrinoFileSystemFactory fileSystemFactory,
@@ -91,7 +90,7 @@ public class HudiSplitSource
             ScheduledExecutorService splitLoaderExecutorService,
             int maxSplitsPerSecond,
             int maxOutstandingSplits,
-            List<String> partitions,
+            Map<String, Partition> partitions,
             DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeoutMillis)
     {
@@ -110,8 +109,6 @@ public class HudiSplitSource
                 tableHandle,
                 metaClient,
                 enableMetadataTable,
-                metastore,
-                table,
                 partitionColumnHandles,
                 partitions,
                 latestCommitTime);
@@ -124,7 +121,7 @@ public class HudiSplitSource
                 queue,
                 new BoundedExecutor(executor, getSplitGeneratorParallelism(session)),
                 createSplitWeightProvider(session),
-                partitions,
+                partitions.keySet().stream().toList(),
                 latestCommitTime,
                 enableMetadataTable,
                 metaClient,

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
-import io.trino.metastore.Column;
 import io.trino.metastore.HivePartition;
 import io.trino.metastore.HiveType;
 import io.trino.plugin.hive.HiveColumnHandle;
@@ -127,7 +126,7 @@ public final class HudiUtil
         return true;
     }
 
-    public static List<HivePartitionKey> buildPartitionKeys(List<Column> keys, List<String> values)
+    public static List<HivePartitionKey> buildPartitionKeys(List<HiveColumnHandle> keys, List<String> values)
     {
         checkCondition(keys.size() == values.size(), HIVE_INVALID_METADATA,
                 "Expected %s partition key values, but got %s. Keys: %s, Values: %s.",

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfo.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfo.java
@@ -13,11 +13,9 @@
  */
 package io.trino.plugin.hudi.partition;
 
-import io.trino.metastore.Partition;
 import io.trino.plugin.hive.HivePartitionKey;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface HudiPartitionInfo
 {
@@ -26,6 +24,4 @@ public interface HudiPartitionInfo
     List<HivePartitionKey> getHivePartitionKeys();
 
     boolean doesMatchPredicates();
-
-    void loadPartitionInfo(Optional<Partition> partition);
 }


### PR DESCRIPTION
## Description

This PR improves the Hudi connector performance by using a batch call to get partition information from the metastore.

## Additional context and related issues

Before this PR, one metastore call is invoked per partition to get information, which significantly increases the planning latency if there are many table partitions to look up.  The improvement reduces the query latency by 20-30s on a table with 1800 partitions.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
*  Improves the Hudi connector performance by using a batch call to get partition information from the metastore
```
