### PR TITLE
[HUDI-9506] Lazily load meta client and file system view to improve Hudi connector performance

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -16,11 +16,10 @@ package io.trino.plugin.hudi;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import io.trino.filesystem.TrinoFileSystemFactory;
+import io.airlift.log.Logger;
 import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.Partition;
 import io.trino.metastore.StorageFormat;
-import io.trino.metastore.Table;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveTransactionHandle;
@@ -35,6 +34,8 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.computePartitionKeyFilter;
 import static io.trino.plugin.hive.util.HiveUtil.getPartitionKeyColumnHandles;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_PARTITION_NOT_FOUND;
@@ -52,17 +52,15 @@ import static io.trino.plugin.hudi.HudiSessionProperties.getDynamicFilteringWait
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxOutstandingSplits;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMaxSplitsPerSecond;
 import static io.trino.plugin.hudi.partition.HiveHudiPartitionInfo.NON_PARTITION;
-import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 public class HudiSplitManager
         implements ConnectorSplitManager
 {
+    private static final Logger log = Logger.get(HudiSplitManager.class);
     private final TypeManager typeManager;
     private final BiFunction<ConnectorIdentity, HiveTransactionHandle, HiveMetastore> metastoreProvider;
-    private final TrinoFileSystemFactory fileSystemFactory;
     private final ExecutorService executor;
     private final ScheduledExecutorService splitLoaderExecutorService;
 
@@ -71,13 +69,11 @@ public class HudiSplitManager
             TypeManager typeManager,
             BiFunction<ConnectorIdentity, HiveTransactionHandle, HiveMetastore> metastoreProvider,
             @ForHudiSplitManager ExecutorService executor,
-            TrinoFileSystemFactory fileSystemFactory,
             @ForHudiSplitSource ScheduledExecutorService splitLoaderExecutorService)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.metastoreProvider = requireNonNull(metastoreProvider, "metastoreProvider is null");
         this.executor = requireNonNull(executor, "executor is null");
-        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.splitLoaderExecutorService = requireNonNull(splitLoaderExecutorService, "splitLoaderExecutorService is null");
     }
 
@@ -91,25 +87,25 @@ public class HudiSplitManager
     {
         HudiTableHandle hudiTableHandle = (HudiTableHandle) tableHandle;
         HiveMetastore metastore = metastoreProvider.apply(session.getIdentity(), (HiveTransactionHandle) transaction);
-        Table table = metastore.getTable(hudiTableHandle.getSchemaName(), hudiTableHandle.getTableName())
-                .orElseThrow(() -> new TableNotFoundException(schemaTableName(hudiTableHandle.getSchemaName(), hudiTableHandle.getTableName())));
-
-        List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table, typeManager);
-        Map<String, HiveColumnHandle> partitionColumnHandles = partitionColumns.stream()
-                .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
-        Map<String, Partition> allPartitions = getPartitions(metastore, hudiTableHandle, table, partitionColumns);
+        List<HiveColumnHandle> partitionColumnHandles = getPartitionKeyColumnHandles(
+                ((HudiTableHandle) tableHandle).getTable(), typeManager);
+        Lazy<Map<String, Partition>> lazyAllPartitions = Lazy.lazily(() -> {
+            HoodieTimer timer = HoodieTimer.start();
+            Map<String, Partition> allPartitions = getPartitions(metastore, hudiTableHandle, partitionColumnHandles);
+            log.info("Found %s partitions for table %s.%s in %s ms",
+                    allPartitions.size(), hudiTableHandle.getSchemaName(), hudiTableHandle.getTableName(), timer.endTimer());
+            return allPartitions;
+        });
 
         HudiSplitSource splitSource = new HudiSplitSource(
                 session,
-                table,
                 hudiTableHandle,
-                fileSystemFactory,
-                partitionColumnHandles,
                 executor,
                 splitLoaderExecutorService,
                 getMaxSplitsPerSecond(session),
                 getMaxOutstandingSplits(session),
-                allPartitions,
+                partitionColumnHandles,
+                lazyAllPartitions,
                 dynamicFilter,
                 getDynamicFilteringWaitTimeout(session));
         return new ClassLoaderSafeConnectorSplitSource(splitSource, HudiSplitManager.class.getClassLoader());
@@ -118,7 +114,6 @@ public class HudiSplitManager
     private static Map<String, Partition> getPartitions(
             HiveMetastore metastore,
             HudiTableHandle tableHandle,
-            Table table,
             List<HiveColumnHandle> partitionColumns)
     {
         if (partitionColumns.isEmpty()) {
@@ -140,7 +135,7 @@ public class HudiSplitManager
                         partitionColumns.stream().map(HiveColumnHandle::getName).collect(Collectors.toList()),
                         computePartitionKeyFilter(partitionColumns, tableHandle.getPartitionPredicates()))
                 .orElseThrow(() -> new TableNotFoundException(tableHandle.getSchemaTableName()));
-        Map<String, Optional<Partition>> partitionsByNames = metastore.getPartitionsByNames(table, partitionNames);
+        Map<String, Optional<Partition>> partitionsByNames = metastore.getPartitionsByNames(tableHandle.getTable(), partitionNames);
         List<String> partitionsNotFound = partitionsByNames.entrySet().stream().filter(e -> e.getValue().isEmpty()).map(Map.Entry::getKey).toList();
         if (!partitionsNotFound.isEmpty()) {
             throw new TrinoException(HUDI_PARTITION_NOT_FOUND, format("Cannot find partitions in metastore: %s", partitionsNotFound));

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -19,9 +19,7 @@ import com.google.common.util.concurrent.Futures;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.Partition;
-import io.trino.metastore.Table;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.util.AsyncQueue;
@@ -40,8 +38,7 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.util.Lazy;
 
 import java.util.HashMap;
 import java.util.List;
@@ -63,11 +60,9 @@ import static io.trino.plugin.hudi.HudiSessionProperties.getSplitGeneratorParall
 import static io.trino.plugin.hudi.HudiSessionProperties.getStandardSplitWeightSize;
 import static io.trino.plugin.hudi.HudiSessionProperties.isHudiMetadataTableEnabled;
 import static io.trino.plugin.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
-import static io.trino.plugin.hudi.HudiUtil.buildTableMetaClient;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.toList;
 
 public class HudiSplitSource
         implements ConnectorSplitSource
@@ -82,35 +77,24 @@ public class HudiSplitSource
 
     public HudiSplitSource(
             ConnectorSession session,
-            Table table,
             HudiTableHandle tableHandle,
-            TrinoFileSystemFactory fileSystemFactory,
-            Map<String, HiveColumnHandle> partitionColumnHandleMap,
             ExecutorService executor,
             ScheduledExecutorService splitLoaderExecutorService,
             int maxSplitsPerSecond,
             int maxOutstandingSplits,
-            Map<String, Partition> partitions,
+            List<HiveColumnHandle> partitionColumnHandles,
+            Lazy<Map<String, Partition>> lazyPartitions,
             DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeoutMillis)
     {
         boolean enableMetadataTable = isHudiMetadataTableEnabled(session);
-        HoodieTableMetaClient metaClient = buildTableMetaClient(fileSystemFactory.create(session), tableHandle.getBasePath());
-        String latestCommitTime = metaClient.getActiveTimeline()
-                .getCommitsTimeline()
-                .filterCompletedInstants()
-                .lastInstant()
-                .map(HoodieInstant::requestedTime)
-                .orElseThrow(() -> new TrinoException(HudiErrorCode.HUDI_NO_VALID_COMMIT, "Table has no valid commits"));
-        List<HiveColumnHandle> partitionColumnHandles = table.getPartitionColumns().stream()
-                .map(column -> partitionColumnHandleMap.get(column.getName())).collect(toList());
+        Lazy<String> latestCommitTime = Lazy.lazily(tableHandle::latestCommitTime);
 
         HudiDirectoryLister hudiDirectoryLister = new HudiSnapshotDirectoryLister(
                 tableHandle,
-                metaClient,
                 enableMetadataTable,
                 partitionColumnHandles,
-                partitions,
+                lazyPartitions,
                 latestCommitTime);
 
         this.queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
@@ -121,13 +105,12 @@ public class HudiSplitSource
                 queue,
                 new BoundedExecutor(executor, getSplitGeneratorParallelism(session)),
                 createSplitWeightProvider(session),
-                partitions.keySet().stream().toList(),
+                lazyPartitions,
                 latestCommitTime,
                 enableMetadataTable,
-                metaClient,
                 throwable -> {
                     trinoException.compareAndSet(null, new TrinoException(HUDI_CANNOT_OPEN_SPLIT,
-                            "Failed to generate splits for " + table.getSchemaTableName(), throwable));
+                            "Failed to generate splits for " + tableHandle.getSchemaTableName(), throwable));
                     queue.finish();
                 });
         this.splitLoaderFuture = splitLoaderExecutorService.schedule(splitLoader, 0, TimeUnit.MILLISECONDS);

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiTableHandle.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiTableHandle.java
@@ -17,16 +17,22 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import io.trino.metastore.Table;
 import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static java.util.Objects.requireNonNull;
 
@@ -37,12 +43,14 @@ public class HudiTableHandle
     private final String tableName;
     private final String basePath;
     private final HoodieTableType tableType;
-    private final Optional<String> preCombineField;
     private final List<HiveColumnHandle> partitionColumns;
     // Used only for validation when config property hudi.query-partition-filter-required is enabled
     private final Set<HiveColumnHandle> constraintColumns;
     private final TupleDomain<HiveColumnHandle> partitionPredicates;
     private final TupleDomain<HiveColumnHandle> regularPredicates;
+    // Coordinator-only
+    private final Optional<Table> table;
+    private final Optional<Lazy<HoodieTableMetaClient>> lazyMetaClient;
 
     @JsonCreator
     public HudiTableHandle(
@@ -50,34 +58,61 @@ public class HudiTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("basePath") String basePath,
             @JsonProperty("tableType") HoodieTableType tableType,
-            @JsonProperty("preCombineField") String preCombineField,
             @JsonProperty("partitionColumns") List<HiveColumnHandle> partitionColumns,
             @JsonProperty("partitionPredicates") TupleDomain<HiveColumnHandle> partitionPredicates,
             @JsonProperty("regularPredicates") TupleDomain<HiveColumnHandle> regularPredicates)
     {
-        this(schemaName, tableName, basePath, tableType, Optional.ofNullable(preCombineField), partitionColumns, ImmutableSet.of(), partitionPredicates, regularPredicates);
+        this(Optional.empty(), Optional.empty(), schemaName, tableName, basePath, tableType, partitionColumns, ImmutableSet.of(), partitionPredicates, regularPredicates);
     }
 
     public HudiTableHandle(
+            Optional<Table> table,
+            Optional<Lazy<HoodieTableMetaClient>> lazyMetaClient,
             String schemaName,
             String tableName,
             String basePath,
             HoodieTableType tableType,
-            Optional<String> preCombineField,
             List<HiveColumnHandle> partitionColumns,
             Set<HiveColumnHandle> constraintColumns,
             TupleDomain<HiveColumnHandle> partitionPredicates,
             TupleDomain<HiveColumnHandle> regularPredicates)
     {
+        this.table = requireNonNull(table, "table is null");
+        this.lazyMetaClient = requireNonNull(lazyMetaClient, "lazyMetaClient is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.basePath = requireNonNull(basePath, "basePath is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
-        this.preCombineField = requireNonNull(preCombineField, "preCombineField is null");
         this.partitionColumns = requireNonNull(partitionColumns, "partitionColumns is null");
         this.constraintColumns = requireNonNull(constraintColumns, "constraintColumns is null");
         this.partitionPredicates = requireNonNull(partitionPredicates, "partitionPredicates is null");
         this.regularPredicates = requireNonNull(regularPredicates, "regularPredicates is null");
+    }
+
+    public Table getTable()
+    {
+        checkArgument(table.isPresent(),
+                "getTable() called on a table handle that has no metastore table object; "
+                        + "this is likely because it is called on the worker.");
+        return table.get();
+    }
+
+    public HoodieTableMetaClient getMetaClient()
+    {
+        checkArgument(lazyMetaClient.isPresent(),
+                "getMetaClient() called on a table handle that has no Hudi meta-client; "
+                        + "this is likely because it is called on the worker.");
+        return lazyMetaClient.get().get();
+    }
+
+    public String latestCommitTime()
+    {
+        return getMetaClient().getActiveTimeline()
+                .getCommitsTimeline()
+                .filterCompletedInstants()
+                .lastInstant()
+                .map(HoodieInstant::requestedTime)
+                .orElseThrow(() -> new TrinoException(HudiErrorCode.HUDI_NO_VALID_COMMIT, "Table has no valid commits"));
     }
 
     @JsonProperty
@@ -102,12 +137,6 @@ public class HudiTableHandle
     public HoodieTableType getTableType()
     {
         return tableType;
-    }
-
-    @JsonProperty
-    public Optional<String> getPreCombineField()
-    {
-        return preCombineField;
     }
 
     @JsonProperty
@@ -146,11 +175,12 @@ public class HudiTableHandle
             TupleDomain<HiveColumnHandle> regularTupleDomain)
     {
         return new HudiTableHandle(
+                table,
+                lazyMetaClient,
                 schemaName,
                 tableName,
                 basePath,
                 tableType,
-                preCombineField,
                 partitionColumns,
                 constraintColumns,
                 partitionPredicates.intersect(partitionTupleDomain),

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/TimelineTable.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/TimelineTable.java
@@ -74,7 +74,7 @@ public class TimelineTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        HoodieTableMetaClient metaClient = buildTableMetaClient(fileSystem, location);
+        HoodieTableMetaClient metaClient = buildTableMetaClient(fileSystem, tableMetadata.getTable().toString(), location);
         Iterable<List<Object>> records = () -> metaClient.getCommitsTimeline().getInstants().stream()
                 .map(this::getRecord).iterator();
         return new InMemoryRecordSet(types, records).cursor();

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfoLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/partition/HudiPartitionInfoLoader.java
@@ -71,7 +71,7 @@ public class HudiPartitionInfoLoader
         partitionInfo.ifPresent(hudiPartitionInfo -> {
             if (hudiPartitionInfo.doesMatchPredicates() || partitionName.equals(NON_PARTITION)) {
                 List<HivePartitionKey> partitionKeys = hudiPartitionInfo.getHivePartitionKeys();
-                List<FileSlice> partitionFileSlices = hudiDirectoryLister.listStatus(hudiPartitionInfo, commitTime);
+                List<FileSlice> partitionFileSlices = hudiDirectoryLister.listStatus(hudiPartitionInfo);
                 partitionFileSlices.stream()
                         .flatMap(slice -> hudiSplitFactory.createSplits(partitionKeys, slice, commitTime).stream())
                         .map(asyncQueue::offer)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiDirectoryLister.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public interface HudiDirectoryLister
         extends Closeable
 {
-    List<FileSlice> listStatus(HudiPartitionInfo partitionInfo, String commitTime);
+    List<FileSlice> listStatus(HudiPartitionInfo partitionInfo);
 
     Optional<HudiPartitionInfo> getPartitionInfo(String partition);
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hudi.query;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.metastore.Partition;
 import io.trino.plugin.hive.HiveColumnHandle;
@@ -25,9 +26,10 @@ import io.trino.spi.connector.SchemaTableName;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.FileSystemViewManager;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -39,27 +41,34 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 public class HudiSnapshotDirectoryLister
         implements HudiDirectoryLister
 {
-    private final HoodieTableFileSystemView fileSystemView;
-    private final Map<String, HudiPartitionInfo> allPartitionInfoMap;
+    private static final Logger log = Logger.get(HudiSnapshotDirectoryLister.class);
+    private final Lazy<String> commitTime;
+    private final Lazy<HoodieTableFileSystemView> lazyFileSystemView;
+    private final Lazy<Map<String, HudiPartitionInfo>> lazyAllPartitionInfoMap;
 
     public HudiSnapshotDirectoryLister(
             HudiTableHandle tableHandle,
-            HoodieTableMetaClient metaClient,
             boolean enableMetadataTable,
             List<HiveColumnHandle> partitionColumnHandles,
-            Map<String, Partition> allPartitions,
-            String commitTime)
+            Lazy<Map<String, Partition>> lazyAllPartitions,
+            Lazy<String> commitTime)
     {
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
                 .enable(enableMetadataTable)
                 .build();
-        this.fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(
-                new HoodieLocalEngineContext(new TrinoStorageConfiguration()), metaClient, metadataConfig);
-        if (enableMetadataTable) {
-            fileSystemView.loadAllPartitions();
-        }
         SchemaTableName schemaTableName = tableHandle.getSchemaTableName();
-        this.allPartitionInfoMap = allPartitions.entrySet().stream()
+        this.commitTime = commitTime;
+        this.lazyFileSystemView = Lazy.lazily(() -> {
+            HoodieTimer timer = HoodieTimer.start();
+            HoodieTableFileSystemView fileSystemView = FileSystemViewManager.createInMemoryFileSystemView(
+                    new HoodieLocalEngineContext(new TrinoStorageConfiguration()), tableHandle.getMetaClient(), metadataConfig);
+            if (enableMetadataTable) {
+                fileSystemView.loadAllPartitions();
+            }
+            log.info("Created file system view of table %s in %s ms", schemaTableName, timer.endTimer());
+            return fileSystemView;
+        });
+        this.lazyAllPartitionInfoMap = Lazy.lazily(() -> lazyAllPartitions.get().entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         e -> new HiveHudiPartitionInfo(
@@ -68,13 +77,14 @@ public class HudiSnapshotDirectoryLister
                                 e.getKey(),
                                 e.getValue(),
                                 partitionColumnHandles,
-                                tableHandle.getPartitionPredicates())));
+                                tableHandle.getPartitionPredicates()))));
     }
 
     @Override
-    public List<FileSlice> listStatus(HudiPartitionInfo partitionInfo, String commitTime)
+    public List<FileSlice> listStatus(HudiPartitionInfo partitionInfo)
     {
-        ImmutableList<FileSlice> collect = fileSystemView.getLatestFileSlicesBeforeOrOn(partitionInfo.getRelativePartitionPath(), commitTime, false)
+        ImmutableList<FileSlice> collect = lazyFileSystemView.get()
+                .getLatestFileSlicesBeforeOrOn(partitionInfo.getRelativePartitionPath(), commitTime.get(), false)
                 .collect(toImmutableList());
         return collect;
     }
@@ -82,14 +92,14 @@ public class HudiSnapshotDirectoryLister
     @Override
     public Optional<HudiPartitionInfo> getPartitionInfo(String partition)
     {
-        return Optional.ofNullable(allPartitionInfoMap.get(partition));
+        return Optional.ofNullable(lazyAllPartitionInfoMap.get().get(partition));
     }
 
     @Override
     public void close()
     {
-        if (fileSystemView != null && !fileSystemView.isClosed()) {
-            fileSystemView.close();
+        if (!lazyFileSystemView.get().isClosed()) {
+            lazyFileSystemView.get().close();
         }
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiBaseIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiBaseIndexSupport.java
@@ -17,6 +17,7 @@ import io.airlift.log.Logger;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -27,12 +28,12 @@ public abstract class HudiBaseIndexSupport
         implements HudiIndexSupport
 {
     private final Logger log;
-    protected final HoodieTableMetaClient metaClient;
+    protected final Lazy<HoodieTableMetaClient> lazyMetaClient;
 
-    public HudiBaseIndexSupport(Logger log, HoodieTableMetaClient metaClient)
+    public HudiBaseIndexSupport(Logger log, Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
         this.log = requireNonNull(log, "log is null");
-        this.metaClient = requireNonNull(metaClient, "metaClient is null");
+        this.lazyMetaClient = requireNonNull(lazyMetaClient, "metaClient is null");
     }
 
     public void printDebugMessage(Map<String, List<FileSlice>> candidateFileSlices, Map<String, List<FileSlice>> inputFileSlices)
@@ -50,10 +51,10 @@ public abstract class HudiBaseIndexSupport
 
     protected Map<String, HoodieIndexDefinition> getAllIndexDefinitions()
     {
-        if (metaClient.getIndexMetadata().isEmpty()) {
+        if (lazyMetaClient.get().getIndexMetadata().isEmpty()) {
             return Map.of();
         }
 
-        return metaClient.getIndexMetadata().get().getIndexDefinitions();
+        return lazyMetaClient.get().getIndexMetadata().get().getIndexDefinitions();
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiColumnStatsIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiColumnStatsIndexSupport.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.hash.ColumnIndexID;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -57,14 +58,14 @@ public class HudiColumnStatsIndexSupport
 {
     private static final Logger log = Logger.get(HudiColumnStatsIndexSupport.class);
 
-    public HudiColumnStatsIndexSupport(HoodieTableMetaClient metaClient)
+    public HudiColumnStatsIndexSupport(Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
-        super(log, metaClient);
+        super(log, lazyMetaClient);
     }
 
-    public HudiColumnStatsIndexSupport(Logger log, HoodieTableMetaClient metaClient)
+    public HudiColumnStatsIndexSupport(Logger log, Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
-        super(log, metaClient);
+        super(log, lazyMetaClient);
     }
 
     @Override
@@ -112,7 +113,7 @@ public class HudiColumnStatsIndexSupport
         boolean isIndexSupported = isIndexSupportAvailable();
         // indexDefinition is only available after table version EIGHT
         // For tables that have versions < EIGHT, column stats index is available as long as partition in metadata is available
-        if (!isIndexSupported || metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
+        if (!isIndexSupported || lazyMetaClient.get().getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
             log.debug("Column Stats Index partition is not enabled in metadata.");
             return isIndexSupported;
         }
@@ -139,7 +140,7 @@ public class HudiColumnStatsIndexSupport
 
     public boolean isIndexSupportAvailable()
     {
-        return metaClient.getTableConfig().getMetadataPartitions()
+        return lazyMetaClient.get().getTableConfig().getMetadataPartitions()
                 .contains(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS);
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiNoOpIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiNoOpIndexSupport.java
@@ -18,6 +18,7 @@ import io.trino.spi.predicate.TupleDomain;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -30,9 +31,9 @@ public class HudiNoOpIndexSupport
 {
     private static final Logger log = Logger.get(HudiNoOpIndexSupport.class);
 
-    public HudiNoOpIndexSupport(HoodieTableMetaClient metaClient)
+    public HudiNoOpIndexSupport(Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
-        super(log, metaClient);
+        super(log, lazyMetaClient);
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiPartitionStatsIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiPartitionStatsIndexSupport.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.hash.ColumnIndexID;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.util.Lazy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +38,9 @@ public class HudiPartitionStatsIndexSupport
 {
     private static final Logger log = Logger.get(HudiColumnStatsIndexSupport.class);
 
-    public HudiPartitionStatsIndexSupport(HoodieTableMetaClient metaClient)
+    public HudiPartitionStatsIndexSupport(Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
-        super(log, metaClient);
+        super(log, lazyMetaClient);
     }
 
     @Override
@@ -104,7 +105,7 @@ public class HudiPartitionStatsIndexSupport
     @Override
     public boolean isIndexSupportAvailable()
     {
-        return metaClient.getTableConfig().getMetadataPartitions()
+        return lazyMetaClient.get().getTableConfig().getMetadataPartitions()
                 .contains(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS);
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiSecondaryIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiSecondaryIndexSupport.java
@@ -22,6 +22,7 @@ import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.util.Lazy;
 
 import java.util.List;
 import java.util.Map;
@@ -37,9 +38,9 @@ public class HudiSecondaryIndexSupport
 {
     private static final Logger log = Logger.get(HudiSecondaryIndexSupport.class);
 
-    public HudiSecondaryIndexSupport(HoodieTableMetaClient metaClient)
+    public HudiSecondaryIndexSupport(Lazy<HoodieTableMetaClient> lazyMetaClient)
     {
-        super(log, metaClient);
+        super(log, lazyMetaClient);
     }
 
     @Override
@@ -48,7 +49,7 @@ public class HudiSecondaryIndexSupport
             Map<String, List<FileSlice>> inputFileSlices,
             TupleDomain<String> regularColumnPredicates)
     {
-        if (regularColumnPredicates.isAll() || metaClient.getIndexMetadata().isEmpty()) {
+        if (regularColumnPredicates.isAll() || lazyMetaClient.get().getIndexMetadata().isEmpty()) {
             log.debug("Predicates cover all data, skipping secondary index lookup.");
             return inputFileSlices;
         }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hudi.split;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.MoreFutures;
+import io.trino.metastore.Partition;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.util.AsyncQueue;
@@ -36,6 +37,7 @@ import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.util.Lazy;
 
 import java.util.ArrayList;
 import java.util.Deque;
@@ -63,11 +65,11 @@ public class HudiBackgroundSplitLoader
     private final Executor splitGeneratorExecutor;
     private final int splitGeneratorNumThreads;
     private final HudiSplitFactory hudiSplitFactory;
-    private final List<String> partitions;
-    private final String commitTime;
+    private final Lazy<List<String>> lazyPartitions;
+    private final Lazy<String> lazyCommitTime;
     private final Consumer<Throwable> errorListener;
     private final boolean enableMetadataTable;
-    private final HoodieTableMetaClient metaClient;
+    private final Lazy<HoodieTableMetaClient> lazyMetaClient;
     private final TupleDomain<HiveColumnHandle> regularPredicates;
     private final Optional<HudiIndexSupport> indexSupportOpt;
     private final Optional<HudiPartitionStatsIndexSupport> partitionIndexSupportOpt;
@@ -79,10 +81,9 @@ public class HudiBackgroundSplitLoader
             AsyncQueue<ConnectorSplit> asyncQueue,
             Executor splitGeneratorExecutor,
             HudiSplitWeightProvider hudiSplitWeightProvider,
-            List<String> partitions,
-            String commitTime,
+            Lazy<Map<String, Partition>> lazyPartitionMap,
+            Lazy<String> lazyCommitTime,
             boolean enableMetadataTable,
-            HoodieTableMetaClient metaClient,
             Consumer<Throwable> errorListener)
     {
         this.hudiDirectoryLister = requireNonNull(hudiDirectoryLister, "hudiDirectoryLister is null");
@@ -90,14 +91,14 @@ public class HudiBackgroundSplitLoader
         this.splitGeneratorExecutor = requireNonNull(splitGeneratorExecutor, "splitGeneratorExecutorService is null");
         this.splitGeneratorNumThreads = getSplitGeneratorParallelism(session);
         this.hudiSplitFactory = new HudiSplitFactory(tableHandle, hudiSplitWeightProvider);
-        this.partitions = requireNonNull(partitions, "partitions is null");
-        this.commitTime = requireNonNull(commitTime, "commitTime is null");
+        this.lazyPartitions = Lazy.lazily(() -> requireNonNull(lazyPartitionMap, "partitions is null").get().keySet().stream().toList());
+        this.lazyCommitTime = requireNonNull(lazyCommitTime, "commitTime is null");
         this.enableMetadataTable = enableMetadataTable;
-        this.metaClient = requireNonNull(metaClient, "metaClient is null");
+        this.lazyMetaClient = Lazy.lazily(tableHandle::getMetaClient);
         this.regularPredicates = tableHandle.getRegularPredicates();
         this.errorListener = requireNonNull(errorListener, "errorListener is null");
-        this.indexSupportOpt = IndexSupportFactory.createIndexSupport(metaClient, regularPredicates, session);
-        this.partitionIndexSupportOpt = IndexSupportFactory.createPartitionStatsIndexSupport(metaClient, regularPredicates, session);
+        this.indexSupportOpt = IndexSupportFactory.createIndexSupport(lazyMetaClient, regularPredicates, session);
+        this.partitionIndexSupportOpt = IndexSupportFactory.createPartitionStatsIndexSupport(lazyMetaClient, regularPredicates, session);
     }
 
     @Override
@@ -124,26 +125,26 @@ public class HudiBackgroundSplitLoader
     {
         // Data Skipping based on column stats
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
-        HoodieEngineContext engineContext = new HoodieLocalEngineContext(metaClient.getStorage().getConf());
+        HoodieEngineContext engineContext = new HoodieLocalEngineContext(lazyMetaClient.get().getStorage().getConf());
         HoodieTableMetadata metadataTable = HoodieTableMetadata.create(
                 engineContext,
-                metaClient.getStorage(), metadataConfig, metaClient.getBasePath().toString(), true);
+                lazyMetaClient.get().getStorage(), metadataConfig, lazyMetaClient.get().getBasePath().toString(), true);
 
         // Attempt to apply partition pruning using partition stats index
         Optional<List<String>> effectivePartitionsOpt = partitionIndexSupportOpt.isPresent() ? partitionIndexSupportOpt.get().prunePartitions(
-                partitions, metadataTable, regularPredicates.transformKeys(HiveColumnHandle::getName)) : Optional.empty();
+                lazyPartitions.get(), metadataTable, regularPredicates.transformKeys(HiveColumnHandle::getName)) : Optional.empty();
 
         // For MDT the file listing is already loaded in memory
         // TODO(yihua): refactor split loader/directory lister API for maintainability
         Map<String, List<FileSlice>> partitionFileSliceMap = new HashMap<>();
         Map<String, List<HivePartitionKey>> partitionToPartitionKeyMap = new HashMap<>();
         // non-partitioned tables have empty strings
-        for (String partitionName : effectivePartitionsOpt.orElse(partitions)) {
+        for (String partitionName : effectivePartitionsOpt.orElse(lazyPartitions.get())) {
             Optional<HudiPartitionInfo> partitionInfo = hudiDirectoryLister.getPartitionInfo(partitionName);
             partitionInfo.ifPresent(hudiPartitionInfo -> {
                 if (hudiPartitionInfo.doesMatchPredicates() || partitionName.equals(NON_PARTITION)) {
                     List<HivePartitionKey> partitionKeys = hudiPartitionInfo.getHivePartitionKeys();
-                    List<FileSlice> partitionFileSlices = hudiDirectoryLister.listStatus(hudiPartitionInfo, commitTime);
+                    List<FileSlice> partitionFileSlices = hudiDirectoryLister.listStatus(hudiPartitionInfo);
                     partitionFileSliceMap.put(partitionName, partitionFileSlices);
                     partitionToPartitionKeyMap.put(partitionName, partitionKeys);
                 }
@@ -155,7 +156,7 @@ public class HudiBackgroundSplitLoader
         prunedFiles.entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream().flatMap(slice ->
                         hudiSplitFactory.createSplits(
-                                partitionToPartitionKeyMap.get(entry.getKey()), slice, commitTime).stream()))
+                                partitionToPartitionKeyMap.get(entry.getKey()), slice, lazyCommitTime.get()).stream()))
                 .map(asyncQueue::offer)
                 .forEachOrdered(MoreFutures::getFutureValue);
         asyncQueue.finish();
@@ -163,13 +164,13 @@ public class HudiBackgroundSplitLoader
 
     private void partitionPruningSplitGenerator()
     {
-        Deque<String> partitionQueue = new ConcurrentLinkedDeque<>(partitions);
+        Deque<String> partitionQueue = new ConcurrentLinkedDeque<>(lazyPartitions.get());
         List<HudiPartitionInfoLoader> splitGeneratorList = new ArrayList<>();
         List<ListenableFuture<Void>> splitGeneratorFutures = new ArrayList<>();
 
         // Start a number of partition split generators to generate the splits in parallel
         for (int i = 0; i < splitGeneratorNumThreads; i++) {
-            HudiPartitionInfoLoader generator = new HudiPartitionInfoLoader(hudiDirectoryLister, commitTime, hudiSplitFactory, asyncQueue, partitionQueue);
+            HudiPartitionInfoLoader generator = new HudiPartitionInfoLoader(hudiDirectoryLister, lazyCommitTime.get(), hudiSplitFactory, asyncQueue, partitionQueue);
             splitGeneratorList.add(generator);
             ListenableFuture<Void> future = Futures.submit(generator, splitGeneratorExecutor);
             addExceptionCallback(future, errorListener);


### PR DESCRIPTION
## Description

This PR makes changes to lazily load meta client and file system view to improve Hudi connector performance.

## Additional context and related issues

The following places eagerly load meta client, file system view, scan files and/or do other costly operation on a table which can delay query planning and block query execution:
- `HudiMetadata#getTableHandle`: checks metadata and reads table config in `.hoodie` folder
- `HudiSplitManager#getSplits`: gets partition information by sending requests to the metastore, instantiates `HudiSplitSource`
- `HudiSplitSource` constructor: builds meta client to load the timeline and gets the latest commit time, instantiates `HudiSnapshotDirectoryLister` and `HudiBackgroundSplitLoader`
- `HudiSnapshotDirectoryLister`: loads file system view

All such costly operation in the constructor that blocks query execution are made lazy so that the splits can be generated faster async while query execution can start as early as possible.  Index support classes also take lazy meta client. To reuse table information, the metastore table object and meta client is stored inside the `HudiTableHandle` for reuse on the coordinator (these two objects are not serialized and sent to workers).

Besides, for base-file-only split, `HudiPageSourceProvide#createPageSource` no longer build meta client (which loads the timeline) and get data schema, which are unnecessary.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hudi connector
* Improves performance by lazily loading meta client and file system view
```
