### PR TITLE
[HUDI-9508] Add logs for split generation in Hudi connector

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -80,9 +80,12 @@ public class HudiSnapshotDirectoryLister
     @Override
     public List<FileSlice> listStatus(HudiPartitionInfo partitionInfo)
     {
+        HoodieTimer timer = HoodieTimer.start();
         ImmutableList<FileSlice> collect = lazyFileSystemView.get()
                 .getLatestFileSlicesBeforeOrOn(partitionInfo.getRelativePartitionPath(), tableHandle.getLatestCommitTime(), false)
                 .collect(toImmutableList());
+        log.info("Listed partition [%s] on table %s.%s in %s ms",
+                partitionInfo, tableHandle.getSchemaName(), tableHandle.getTableName(), timer.endTimer());
         return collect;
     }
 


### PR DESCRIPTION
## Description

This PR adds logs for split generation in Hudi connector for easily understanding the query planning.

## Additional context and related issues

As above

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hudi Connector
* Adds logs for split generation
```
