### PR TITLE
[HUDI-9427] Add test to cover partition pruning and dynamic filtering for nested partitions

### DIFF
--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -636,7 +636,7 @@ public class TestHudiSmokeTest
                 .isEqualTo(expectedInputRowsAfterFiltering);
 
         // Exercise query and check output
-        assertQuery(query, "SELECT * FROM VALUES (1, 'a1', 100.0, 1000), (3, 'a3', 101.0, 1001)");
+        assertQuery(query, "VALUES (1, 'a1', 100.0, 1000), (3, 'a3', 101.0, 1001)");
     }
 
     @ParameterizedTest
@@ -664,7 +664,7 @@ public class TestHudiSmokeTest
                 .isFalse();
 
         // Skip check on whether optimization is not applied or not, just check that output is queryable
-        assertQuery(query, "SELECT * FROM VALUES (1, 'a1', 100.0, 1000), (3, 'a3', 101.0, 1001)");
+        assertQuery(query, "VALUES (1, 'a1', 100.0, 1000), (3, 'a3', 101.0, 1001)");
     }
 
     @ParameterizedTest
@@ -675,7 +675,7 @@ public class TestHudiSmokeTest
     {
         Session session = SessionBuilder.from(getSession()).build();
         final String tableIdentifier = "hudi:tests." + table.getRoTableName();
-        // Query is joined-on recordKey and partitionField
+        // Query is joined-on partitionField
         @Language("SQL") String query = "SELECT t1.id, t1.name, t1.price, t1.ts, t1.country FROM " +
                 table + " t1 " +
                 "INNER JOIN " + table + " t2 ON t1.country = t2.country " +
@@ -698,7 +698,42 @@ public class TestHudiSmokeTest
                 .isEqualTo(expectedInputRowsAfterFiltering);
 
         // Exercise query and check output
-        assertQuery(query, "SELECT * FROM VALUES (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG'), (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG')");
+        assertQuery(query, "VALUES (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG'), (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG')");
+    }
+
+    @Test
+    public void testDynamicFilterEnabled_withPartitionPruningUsingDynamicFilterOnNestedPartitions()
+    {
+        Session session = SessionBuilder.from(getSession())
+                .withDynamicFilterTimeout("10s")
+                .build();
+        final String tableIdentifier = "hudi:tests." + HUDI_MULTI_PT_V8_MOR.getRoTableName();
+        // Query is joined-on recordKey and partitionField
+        @Language("SQL") String query = "SELECT t1.id FROM " +
+                HUDI_MULTI_PT_V8_MOR + " t1 " +
+                "INNER JOIN " + HUDI_MULTI_PT_V8_MOR + " t2 ON t1.id = t2.id AND t1.part_int = t2.part_int " +
+                "WHERE t2.part_int = 2023";
+
+        MaterializedResult explainRes = getQueryRunner().execute(session, "EXPLAIN ANALYZE " + query);
+        Pattern scanFilterInputRowsPattern = getScanFilterInputRowsPattern(tableIdentifier);
+        Matcher matcher = scanFilterInputRowsPattern.matcher(explainRes.toString());
+        assertThat(matcher.find())
+                .withFailMessage("Could not find 'ScanFilter' for table '%s' with 'dynamicFilters' and 'Input: X rows' stats in EXPLAIN output.\nOutput was:\n%s",
+                        tableIdentifier, explainRes.toString())
+                .isTrue();
+
+        // matcher#group() must be invoked after matcher#find()
+        String rowsInputString = matcher.group(1);
+        long actualInputRows = Long.parseLong(rowsInputString);
+        // 1 row in each split, should only scan 3 splits, i.e. 3 rows
+        // For a more strict search, we can check the number of splits scanned on the builder side
+        long expectedInputRowsAfterFiltering = 3;
+        assertThat(actualInputRows)
+                .describedAs("Number of rows input to the ScanFilter for the probe side table (%s) should reflect effective dynamic filtering", tableIdentifier)
+                .isEqualTo(expectedInputRowsAfterFiltering);
+
+        // Exercise query and check output
+        assertQuery(query, "VALUES (1), (2), (4)");
     }
 
     @ParameterizedTest
@@ -728,7 +763,26 @@ public class TestHudiSmokeTest
 
         // Skip check on whether optimization is not applied or not, just check that output is queryable
         // Cartesian product of result is produced since we are joining by partition column
-        assertQuery(query, "SELECT * FROM VALUES (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG'), (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG')");
+        assertQuery(query, "VALUES (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG'), (1, 'a1', 100.0, 1000, 'SG'), (3, 'a3', 101.0, 1001, 'SG')");
+    }
+
+    @Test
+    public void testPartitionPruningOnNestedPartitions()
+    {
+        // Should only scan paths that match the part_str=*/part_int=2023/part_date=*/part_bigint=*/part_decimal=*/part_timestamp=*/part_bool=*
+        Session session = getSession();
+        // No partition pruning
+        @Language("SQL") String actualQuery = "SELECT part_str, part_int, part_date, part_bigint, part_bool FROM " + HUDI_MULTI_PT_V8_MOR;
+        MaterializedResult actualRes = getQueryRunner().execute(session, actualQuery);
+        int actualTotalSplits = actualRes.getStatementStats().get().getTotalSplits();
+        assertThat(actualTotalSplits).isEqualTo(5);
+
+        // With partition pruning
+        @Language("SQL") String actualPartPruneQuery = actualQuery + " WHERE part_int = 2023";
+        MaterializedResult actualPartPruneRes = getQueryRunner().execute(session, actualPartPruneQuery);
+        int actualPartPruneSplits = actualPartPruneRes.getStatementStats().get().getTotalSplits();
+        assertThat(actualPartPruneSplits).isLessThan(actualTotalSplits);
+        assertThat(actualPartPruneSplits).isEqualTo(3);
     }
 
     @ParameterizedTest


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adding tests for V8 tables to verify that:
1. Partition pruning works for tables with nested partitions and when partition filters are applied on non-top-level partitions
    - This is verified by querying a non-top-level partition and checking number of splits scanned if the only predicate is a partition filter
2. Dynamic filtering works for tables with nested partitions when partition filters are applied on non-top-level partitions
    - This is verified by performing an INNERJOIN on the recordKey and a non-top-level-partition partitionField and applying a predicate on a non-top-level-partition


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
