### PR TITLE
[HUDI-9537] Fix dependency in Hudi connector

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -129,7 +129,19 @@
             <version>${dep.hudi.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>*</groupId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>


### PR DESCRIPTION
## Description

This PR fixes the dependency in Hudi connector.

## Additional context and related issues

Prior to this fix, all transitive dependencies of `hudi-common` were excluded, causing required classes to be missing.
```
java.lang.NoClassDefFoundError: net/jpountz/xxhash/XXHashFactory
	at org.apache.hudi.common.util.hash.HashID.getXXHash(HashID.java:139)
	at org.apache.hudi.common.util.hash.HashID.hash(HashID.java:103)
	at org.apache.hudi.common.util.hash.HashID.hash(HashID.java:89)
	at org.apache.hudi.common.util.hash.PartitionIndexID.<init>(PartitionIndexID.java:36)
	at io.trino.plugin.hudi.stats.TableMetadataReader.lambda$computeColumnStatsLookupKeys$0(TableMetadataReader.java:76)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:636)
	at java.base/java.util.stream.ReferencePipeline$7$1FlatMap.accept(ReferencePipeline.java:294)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:636)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:291)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:656)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:662)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:667)
	at io.trino.plugin.hudi.stats.TableMetadataReader.computeColumnStatsLookupKeys(TableMetadataReader.java:79)
	at io.trino.plugin.hudi.stats.TableMetadataReader.getColumnStats(TableMetadataReader.java:61)
	at io.trino.plugin.hudi.stats.TableStatisticsReader.getColumnStats(TableStatisticsReader.java:115)
	at io.trino.plugin.hudi.stats.TableStatisticsReader.getTableStatistics(TableStatisticsReader.java:75)
	at io.trino.plugin.hudi.HudiMetadata.lambda$triggerAsyncStatsRefresh$13(HudiMetadata.java:480)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.ClassNotFoundException: net.jpountz.xxhash.XXHashFactory
	... 33 more
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hudi connector
* Fixes the `hudi-common` dependency
```
