### PR TITLE
[MINOR] Added optimizations for HudiColumnStatsIndexSupport

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiPartitionStatsIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiPartitionStatsIndexSupport.java
@@ -18,7 +18,9 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hudi.util.TupleDomainUtils;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -32,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.trino.plugin.hudi.util.TupleDomainUtils.hasSimpleNullCheck;
@@ -70,8 +71,11 @@ public class HudiPartitionStatsIndexSupport
                 .stream()
                 .map(col -> new ColumnIndexID(col).asBase64EncodedString()).toList();
 
+        Map<String, Type> columnTypes = regularColumnPredicates.getDomains().get().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getType()));
+
         // Map of partition stats keyed by partition name
-        Map<String, Map<String, HoodieMetadataColumnStats>> statsByPartitionName = lazyMetadataTable.get().getRecordsByKeyPrefixes(
+        Map<String, Map<String, Domain>> statsByPartitionName = lazyMetadataTable.get().getRecordsByKeyPrefixes(
                         encodedTargetColumnNames,
                         HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, true)
                 .collectAsList()
@@ -82,13 +86,14 @@ public class HudiPartitionStatsIndexSupport
                         HoodieMetadataColumnStats::getFileName,
                         Collectors.toMap(
                                 HoodieMetadataColumnStats::getColumnName,
-                                Function.identity())));
+                                // Pre-compute the Domain object for each HoodieMetadataColumnStats
+                                stats -> getDomain(stats.getColumnName(), columnTypes.get(stats.getColumnName()), stats))));
 
         // For each partition, determine if it should be kept based on stats availability and predicate evaluation
         List<String> prunedPartitions = allPartitions.stream()
                 .filter(partition -> {
                     // Check if stats exist for this partition
-                    Map<String, HoodieMetadataColumnStats> partitionStats = statsByPartitionName.get(partition);
+                    Map<String, Domain> partitionStats = statsByPartitionName.get(partition);
                     if (partitionStats == null) {
                         // Partition has no stats in the index, keep it
                         return true;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

### Optimization 1
~~Original `HudiColumnStatsIndexSupport#shouldSkipFileSlice`  is blocking for a timeout, this optimization makes it unblocking, and at the same time, retains all other original behaviour, i.e. If somewhere along the query lifecycle metadata is ready, metadata will still be used for file pruning.~~

Will exclude this for now.

### Optimization 2
The original code creates a `Domain` object for every fileslice. We can optimize this by prebuilding the Domain at the `HoodieMetadataColumnStats` level. This can drastically reduce the number of objects created, and inturn, GC pressure if there are many fileslices to check.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
