### PR TITLE
[ENG-29373] Fix split generation parallelism for a non-partitioned table

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hudi;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
-import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.cache.CachingHostAddressProvider;
@@ -62,7 +61,6 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static io.trino.plugin.hudi.HudiErrorCode.HUDI_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMinimumAssignedSplitWeight;
-import static io.trino.plugin.hudi.HudiSessionProperties.getSplitGeneratorParallelism;
 import static io.trino.plugin.hudi.HudiSessionProperties.getStandardSplitWeightSize;
 import static io.trino.plugin.hudi.HudiSessionProperties.isHudiMetadataTableEnabled;
 import static io.trino.plugin.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
@@ -118,7 +116,7 @@ public class HudiSplitSource
                 tableHandle,
                 hudiDirectoryLister,
                 queue,
-                new BoundedExecutor(executor, getSplitGeneratorParallelism(session)),
+                executor,
                 createSplitWeightProvider(session),
                 lazyPartitions,
                 enableMetadataTable,

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -123,7 +123,7 @@ public class HudiBackgroundSplitLoader
         int splitGeneratorParallelism = Math.min(splitGeneratorNumThreads, lazyPartitions.get().size());
         Executor splitGeneratorExecutor = new BoundedExecutor(executor, splitGeneratorParallelism);
 
-        for (int i = 0; i < Math.min(splitGeneratorNumThreads, partitionQueue.size()); i++) {
+        for (int i = 0; i < splitGeneratorParallelism; i++) {
             HudiPartitionInfoLoader generator = new HudiPartitionInfoLoader(hudiDirectoryLister, tableHandle.getLatestCommitTime(), hudiSplitFactory,
                     asyncQueue, partitionQueue, useIndex);
             splitGenerators.add(generator);

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hudi.split;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.log.Logger;
 import io.trino.filesystem.cache.CachingHostAddressProvider;
 import io.trino.metastore.Partition;
@@ -39,6 +40,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -55,7 +57,7 @@ public class HudiBackgroundSplitLoader
     private final HudiTableHandle tableHandle;
     private final HudiDirectoryLister hudiDirectoryLister;
     private final AsyncQueue<ConnectorSplit> asyncQueue;
-    private final Executor splitGeneratorExecutor;
+    private final Executor executor;
     private final int splitGeneratorNumThreads;
     private final HudiSplitFactory hudiSplitFactory;
     private final Lazy<List<String>> lazyPartitions;
@@ -68,7 +70,7 @@ public class HudiBackgroundSplitLoader
             HudiTableHandle tableHandle,
             HudiDirectoryLister hudiDirectoryLister,
             AsyncQueue<ConnectorSplit> asyncQueue,
-            Executor splitGeneratorExecutor,
+            ExecutorService executor,
             HudiSplitWeightProvider hudiSplitWeightProvider,
             Lazy<Map<String, Partition>> lazyPartitionMap,
             boolean enableMetadataTable,
@@ -79,11 +81,11 @@ public class HudiBackgroundSplitLoader
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.hudiDirectoryLister = requireNonNull(hudiDirectoryLister, "hudiDirectoryLister is null");
         this.asyncQueue = requireNonNull(asyncQueue, "asyncQueue is null");
-        this.splitGeneratorExecutor = requireNonNull(splitGeneratorExecutor, "splitGeneratorExecutorService is null");
         this.splitGeneratorNumThreads = getSplitGeneratorParallelism(session);
         this.hudiSplitFactory = new HudiSplitFactory(tableHandle, hudiSplitWeightProvider, getTargetSplitSize(session), cachingHostAddressProvider);
         this.lazyPartitions = Lazy.lazily(() -> requireNonNull(lazyPartitionMap, "partitions is null").get().keySet().stream().toList());
         this.enableMetadataTable = enableMetadataTable;
+        this.executor = requireNonNull(executor, "executor is null");
         this.errorListener = requireNonNull(errorListener, "errorListener is null");
         SchemaTableName schemaTableName = tableHandle.getSchemaTableName();
         this.partitionIndexSupportOpt = enableMetadataTable ?
@@ -118,7 +120,10 @@ public class HudiBackgroundSplitLoader
         List<HudiPartitionInfoLoader> splitGenerators = new ArrayList<>();
         List<ListenableFuture<Void>> futures = new ArrayList<>();
 
-        for (int i = 0; i < splitGeneratorNumThreads; i++) {
+        int splitGeneratorParallelism = Math.min(splitGeneratorNumThreads, lazyPartitions.get().size());
+        Executor splitGeneratorExecutor = new BoundedExecutor(executor, splitGeneratorParallelism);
+
+        for (int i = 0; i < Math.min(splitGeneratorNumThreads, partitionQueue.size()); i++) {
             HudiPartitionInfoLoader generator = new HudiPartitionInfoLoader(hudiDirectoryLister, tableHandle.getLatestCommitTime(), hudiSplitFactory,
                     asyncQueue, partitionQueue, useIndex);
             splitGenerators.add(generator);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix creating extra HudiPartitionInfoLoader tasks when table is non-partitioned or contains fewer partitions than configured split generator parallelism

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
