### PR TITLE
[HUDI-9577] Make target result size configurable from endpoint and server

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -108,6 +108,7 @@ import io.trino.metadata.Split;
 import io.trino.operator.ForScheduler;
 import io.trino.operator.OperatorStats;
 import io.trino.server.protocol.ExecutingStatementResource;
+import io.trino.server.protocol.ExecutingStatementResourceConfig;
 import io.trino.server.protocol.QueryInfoUrlFactory;
 import io.trino.server.remotetask.RemoteTaskStats;
 import io.trino.server.ui.WebUiModule;
@@ -175,6 +176,7 @@ public class CoordinatorModule
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();
         binder.bind(QueryInfoUrlFactory.class).in(Scopes.SINGLETON);
 
+        configBinder(binder).bindConfig(ExecutingStatementResourceConfig.class);
         // allow large prepared statements in headers
         configBinder(binder).bindConfigDefaults(HttpServerConfig.class, config -> {
             config.setMaxRequestHeaderSize(DataSize.of(2, MEGABYTE));

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResourceConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResourceConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MinDataSize;
+
+public class ExecutingStatementResourceConfig
+{
+    static final String MIN_TARGET_RESULT_SIZE = "1MB";
+    static final String MAX_TARGET_RESULT_SIZE = "128MB";
+    private DataSize targetResultSize = DataSize.valueOf(MIN_TARGET_RESULT_SIZE);
+
+    @MinDataSize(MIN_TARGET_RESULT_SIZE)
+    @MaxDataSize(MAX_TARGET_RESULT_SIZE)
+    public DataSize getTargetResultSize()
+    {
+        return targetResultSize;
+    }
+
+    @Config("query.target-result-size")
+    @ConfigDescription("Target result size for a single response for query results streamed from coordinator to client")
+    public ExecutingStatementResourceConfig setTargetResultSize(DataSize targetResultSize)
+    {
+        this.targetResultSize = targetResultSize;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResourceConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResourceConfig.java
@@ -22,7 +22,7 @@ import io.airlift.units.MinDataSize;
 public class ExecutingStatementResourceConfig
 {
     static final String MIN_TARGET_RESULT_SIZE = "1MB";
-    static final String MAX_TARGET_RESULT_SIZE = "128MB";
+    static final String MAX_TARGET_RESULT_SIZE = "1024MB";
     private DataSize targetResultSize = DataSize.valueOf(MIN_TARGET_RESULT_SIZE);
 
     @MinDataSize(MIN_TARGET_RESULT_SIZE)

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestExecutingStatementResourceConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestExecutingStatementResourceConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol;
+
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class TestExecutingStatementResourceConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ExecutingStatementResourceConfig.class)
+                .setTargetResultSize(DataSize.of(1, MEGABYTE)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("query.target-result-size", "4MB")
+                .build();
+
+        ExecutingStatementResourceConfig expected = new ExecutingStatementResourceConfig()
+                .setTargetResultSize(DataSize.of(4, MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
## Description

This PR makes target result size configurable from endpoint through query parameter `targetResultSize` and server through coordinator config `query.target-result-size`. 

## Additional context and related issues

When a query's result set is large, e.g., 7+ million rows with 100s MB or even GBs of data, the default size, 1MB, for streaming results from the coordinator to the query client through pagination can lead to poor performance.  We have observed this with latest Trino which has 1MB as the size. See another user report a while back (https://github.com/trinodb/trino/issues/22303#issuecomment-2186005610):
```
What I have observed is in code targetResultSize was set as QueryParam and was never getting used or set from trino client while running a query, so I was just curious on why it was not done.

I have run a query which returns approximately 6GB of data with 7.7Million rows on a trino cluster from DBVisualizer using trino-jdbc client driver jar, these are my findigs:

When targetResultSize is default i.e 16MB it took 1hour to fetch this result
When targetResultSize is made maximum i.e 128MB it took 4minutes to fetch this result
```

This PR brings back the query parameter `targetResultSize` that controls this (the parameter is added by prestodb/presto#11619, removed by https://github.com/trinodb/trino/commit/8b61b4f6bdaacb6a32948f926a0c5d33 recently), and adds server-side control as well through coordinator config `query.target-result-size`, by cherrypicking trinodb/trino#4347 (other relevant PRs: trinodb/trino#4347,  trinodb/trino#3017, trinodb/trino#2347, issues: https://github.com/trinodb/trino/issues/2216 https://github.com/trinodb/trino/issues/2210, https://github.com/trinodb/trino/issues/22303).

[Spooling protocol](https://trino.io/docs/current/client/client-protocol.html#spooling-protocol) could be used to improve the performance in this case too; however it requires client to support the spooling protocol with additional secrets and the clients must have access to the object storage, which adds operational overhead.  So, the target result size still serves as a valid optimization option.

We might want to add the session property in the future by incorporating prestodb/presto#14641.  Not necessary for now.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Trino
* Makes target result size configurable from endpoint through query parameter `targetResultSize` and server through coordinator config `query.target-result-size`
```
