### PR TITLE
[ENG-30914] Fix flakiness when testing cache correctness

### DIFF
--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
@@ -26,6 +26,7 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,6 +44,7 @@ import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TABLE_PROPER
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.stream.Collectors.toCollection;
 
+@ResourceLock("HUDI_CACHE_SYSTEM")
 @Execution(ExecutionMode.SAME_THREAD)
 public class TestHudiAlluxioCacheFileOperations
         extends AbstractTestQueryFramework

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCachingSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCachingSmokeTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hudi;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,6 +25,7 @@ import java.nio.file.Path;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 
+@ResourceLock("HUDI_CACHE_SYSTEM")
 public class TestHudiAlluxioCachingSmokeTest
         extends TestHudiSmokeTest
 {

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
@@ -26,6 +26,7 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.util.Map;
 
@@ -40,6 +41,7 @@ import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TABLE_PROPER
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.stream.Collectors.toCollection;
 
+@ResourceLock("HUDI_CACHE_SYSTEM")
 @Execution(ExecutionMode.SAME_THREAD)
 public class TestHudiMemoryCacheFileOperations
         extends AbstractTestQueryFramework


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

There seems to be some test interference causing flakiness when tests are executed together and they are:
1. `TestHudiAlluxioCachingSmokeTest` and `TestHudiMemoryCacheFileOperations`
2. `TestHudiAlluxioCachingSmokeTest` and `TestHudiMemoryCacheFileOperations`

I am not particularly sure what is causing this issue, but i highly suspect that it may be caused by the usage of static in-memory objects.

While the tests uses its own `cacheDirectory`, `TestHudiAlluxioCachingSmokeTest` execution causes the Hudi connector to read table metadata, discover partitions, and load other information. 

The connectors often use static `com.google.common.cache.Cache` and these caches are part of the connector's static state and are not cleared between the execution of different test classes in the same JVM, which the tests will be running in together (verified to be running in parallel).

If these tests are expected to use the static in-memory cache, they can interfere with each other especially if they are running in the same JVM. Hence, the way i have fixed them is to ensure that they are not running together for now. 

While this may not be robust, it is the easiest way to workaround the problem. 

The most robust way of fixing this is to not use exact integer comparisons to verify that cache is working, but rather, get a baseline control value (`value_a`) of file hits without cache and another value with cache enabled (`value_b`). To test for correct cache behaviour, `value_a` should be MORE than `value_b`. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
