### PR TITLE
[ENG-31282] [Trino] Workers should use latest commit time from table handle

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -166,8 +166,8 @@ public class HudiMetadata
                 Optional.of(Lazy.lazily(() -> getLatestTableSchema(lazyMetaClient.get(), tableName.getTableName()))) : Optional.empty();
 
         return new HudiTableHandle(
-                Optional.of(table),
-                Optional.of(lazyMetaClient),
+                table,
+                lazyMetaClient,
                 tableName.getSchemaName(),
                 tableName.getTableName(),
                 table.getStorage().getLocation(),

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -219,7 +219,6 @@ public class HudiPageSourceProvider
         // TODO: Move this into HudiTableHandle
         HoodieTableMetaClient metaClient = buildTableMetaClient(
                 fileSystemFactory.create(session), hudiTableHandle.getSchemaTableName().toString(), hudiTableHandle.getBasePath());
-        String latestCommitTime = metaClient.getCommitsTimeline().lastInstant().get().requestedTime();
 
         HudiTrinoReaderContext readerContext = new HudiTrinoReaderContext(
                 dataPageSource,
@@ -237,7 +236,7 @@ public class HudiPageSourceProvider
                         readerContext,
                         new HudiTrinoStorage(fileSystemFactory.create(session), new TrinoStorageConfiguration()),
                         hudiTableHandle.getBasePath(),
-                        latestCommitTime,
+                        hudiTableHandle.getLatestCommitTime(),
                         convertToFileSlice(hudiSplit, hudiTableHandle.getBasePath()),
                         dataSchema,
                         requestedSchema,

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/split/TestHudiSplitFactory.java
@@ -183,7 +183,8 @@ public class TestHudiSplitFactory
                 ImmutableList.of(),
                 TupleDomain.all(),
                 TupleDomain.all(),
-                "");
+                "",
+                "101");
     }
 
     private static FileSlice createFileSlice(DataSize baseFileSize, Option<DataSize> logFileSize)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

**Problem**
Each Trino worker currently determines the latest commit by independently loading it from the Hudi timeline when reading table splits. If new commits are written during query execution, workers may observe different latest commits, leading to inconsistencies.

**Fix**
This PR changes the behavior so that the coordinator resolves the latest commit once and embeds it in the HudiTableHandle. Workers then use this commit time directly, ensuring all of them read from a consistent snapshot.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
