### PR TITLE
[ENG-31327] [Trino] Fix flaky tests due to table stats computation lagging behind query execution

### DIFF
--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
@@ -140,6 +140,7 @@ public class TestHudiAlluxioCacheFileOperations
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         queryRunner.executeWithPlan(queryRunner.getDefaultSession(), query);
+        // Allow time for table stats computation to finish before validation.
         Thread.sleep(1000L);
         assertMultisetsEqual(getFileOperations(queryRunner), expectedCacheAccesses);
     }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
@@ -130,6 +130,7 @@ public class TestHudiMemoryCacheFileOperations
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         queryRunner.executeWithPlan(queryRunner.getDefaultSession(), query);
+        // Allow time for table stats computation to finish before validation.
         Thread.sleep(1000L);
         assertMultisetsEqual(getFileOperations(queryRunner), expectedCacheAccesses);
     }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiNoCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiNoCacheFileOperations.java
@@ -130,6 +130,7 @@ public class TestHudiNoCacheFileOperations
     {
         DistributedQueryRunner queryRunner = getDistributedQueryRunner();
         queryRunner.executeWithPlan(queryRunner.getDefaultSession(), query);
+        // Allow time for table stats computation to finish before validation.
         Thread.sleep(1000L);
         assertMultisetsEqual(getFileOperations(queryRunner), expectedCacheAccesses);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Tests on File access operations have been flaky after we enabled metadata table by default. This pr fixes it by adding sleep time after query execution which allows table stats compute to be completed.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
