### PR TITLE
[ENG-31801] [Trino] Disable resolve column name casing by default

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -55,7 +55,7 @@ public class HudiConfig
     private boolean queryPartitionFilterRequired;
     private boolean ignoreAbsentPartitions;
     private Duration dynamicFilteringWaitTimeout = new Duration(1, SECONDS);
-    private boolean resolveColumnNameCasingEnabled = true;
+    private boolean resolveColumnNameCasingEnabled;
 
     // Internal configuration for debugging and testing
     private boolean isRecordLevelIndexEnabled = true;

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/SessionBuilder.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/SessionBuilder.java
@@ -25,6 +25,7 @@ import static io.trino.plugin.hudi.HudiSessionProperties.PARTITION_STATS_INDEX_E
 import static io.trino.plugin.hudi.HudiSessionProperties.QUERY_PARTITION_FILTER_REQUIRED;
 import static io.trino.plugin.hudi.HudiSessionProperties.RECORD_INDEX_WAIT_TIMEOUT;
 import static io.trino.plugin.hudi.HudiSessionProperties.RECORD_LEVEL_INDEX_ENABLED;
+import static io.trino.plugin.hudi.HudiSessionProperties.RESOLVE_COLUMN_NAME_CASING_ENABLED;
 import static io.trino.plugin.hudi.HudiSessionProperties.SECONDARY_INDEX_ENABLED;
 import static io.trino.plugin.hudi.HudiSessionProperties.SECONDARY_INDEX_WAIT_TIMEOUT;
 import static io.trino.plugin.hudi.HudiSessionProperties.TABLE_STATISTICS_ENABLED;
@@ -139,5 +140,10 @@ public class SessionBuilder
     public SessionBuilder withRecordIndexTimeout(String durationProp)
     {
         return setCatalogProperty(RECORD_INDEX_WAIT_TIMEOUT, durationProp);
+    }
+
+    public SessionBuilder withResolveColumnNameCasingEnabled(boolean enabled)
+    {
+        return setCatalogProperty(RESOLVE_COLUMN_NAME_CASING_ENABLED, String.valueOf(enabled));
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiAlluxioCacheFileOperations.java
@@ -38,11 +38,9 @@ import static io.trino.filesystem.tracing.CacheFileSystemTraceUtils.getCacheOper
 import static io.trino.plugin.hudi.testing.ResourceHudiTablesInitializer.TestingTable.HUDI_MULTI_FG_PT_V8_MOR;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.DATA;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.INDEX_DEFINITION;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.LOG;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE_PROPERTIES;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TABLE_PROPERTIES;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TIMELINE;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.stream.Collectors.toCollection;
 
@@ -85,12 +83,8 @@ public class TestHudiAlluxioCacheFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation("Alluxio.readCached", DATA), 2)
                         .addCopies(new FileOperation("Alluxio.readCached", METADATA_TABLE), 27)
-                        .addCopies(new FileOperation("Alluxio.readCached", TIMELINE), 4)
-                        .addCopies(new FileOperation("Alluxio.readCached", LOG), 15)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("InputFile.length", METADATA_TABLE), 10)
-                        .addCopies(new FileOperation("InputFile.length", TIMELINE), 2)
-                        .addCopies(new FileOperation("InputFile.length", LOG), 1)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
@@ -101,12 +95,8 @@ public class TestHudiAlluxioCacheFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation("Alluxio.readCached", DATA), 2)
                         .addCopies(new FileOperation("Alluxio.readCached", METADATA_TABLE), 27)
-                        .addCopies(new FileOperation("Alluxio.readCached", TIMELINE), 4)
-                        .addCopies(new FileOperation("Alluxio.readCached", LOG), 15)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("InputFile.length", METADATA_TABLE), 10)
-                        .addCopies(new FileOperation("InputFile.length", TIMELINE), 2)
-                        .addCopies(new FileOperation("InputFile.length", LOG), 1)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
@@ -126,12 +116,8 @@ public class TestHudiAlluxioCacheFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation("Alluxio.readCached", DATA), 6)
                         .addCopies(new FileOperation("Alluxio.readCached", METADATA_TABLE), 288)
-                        .addCopies(new FileOperation("Alluxio.readCached", TIMELINE), 8)
-                        .addCopies(new FileOperation("Alluxio.readCached", LOG), 30)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 39)
                         .addCopies(new FileOperation("InputFile.length", METADATA_TABLE), 93)
-                        .addCopies(new FileOperation("InputFile.length", TIMELINE), 4)
-                        .addCopies(new FileOperation("InputFile.length", LOG), 2)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 5)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 3)
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 5)
@@ -141,12 +127,8 @@ public class TestHudiAlluxioCacheFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation("Alluxio.readCached", DATA), 6)
                         .addCopies(new FileOperation("Alluxio.readCached", METADATA_TABLE), 215)
-                        .addCopies(new FileOperation("Alluxio.readCached", TIMELINE), 8)
-                        .addCopies(new FileOperation("Alluxio.readCached", LOG), 30)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 29)
                         .addCopies(new FileOperation("InputFile.length", METADATA_TABLE), 69)
-                        .addCopies(new FileOperation("InputFile.length", TIMELINE), 4)
-                        .addCopies(new FileOperation("InputFile.length", LOG), 2)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 4)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 2)
                         .addCopies(new FileOperation("InputFile.newStream", TABLE_PROPERTIES), 4)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -59,7 +59,7 @@ public class TestHudiConfig
                 .setSecondaryIndexWaitTimeout(Duration.valueOf("2s"))
                 .setMetadataPartitionListingEnabled(true)
                 .setMetadataCacheEnabled(true)
-                .setResolveColumnNameCasingEnabled(true));
+                .setResolveColumnNameCasingEnabled(false));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class TestHudiConfig
                 .put("hudi.index.secondary-index.wait-timeout", "1s")
                 .put("hudi.metadata.cache.enabled", "false")
                 .put("hudi.metadata.partition-listing.enabled", "false")
-                .put("hudi.table.resolve-column-name-casing.enabled", "false")
+                .put("hudi.table.resolve-column-name-casing.enabled", "true")
                 .buildOrThrow();
 
         HudiConfig expected = new HudiConfig()
@@ -124,7 +124,7 @@ public class TestHudiConfig
                 .setSecondaryIndexWaitTimeout(Duration.valueOf("1s"))
                 .setMetadataPartitionListingEnabled(false)
                 .setMetadataCacheEnabled(false)
-                .setResolveColumnNameCasingEnabled(false);
+                .setResolveColumnNameCasingEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMemoryCacheFileOperations.java
@@ -35,11 +35,9 @@ import static io.trino.filesystem.tracing.CacheFileSystemTraceUtils.isTrinoSchem
 import static io.trino.plugin.hudi.testing.ResourceHudiTablesInitializer.TestingTable.HUDI_MULTI_FG_PT_V8_MOR;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.DATA;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.INDEX_DEFINITION;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.LOG;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE_PROPERTIES;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TABLE_PROPERTIES;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TIMELINE;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.stream.Collectors.toCollection;
 
@@ -76,8 +74,6 @@ public class TestHudiMemoryCacheFileOperations
                         .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 2)
                         .addCopies(new FileOperation("FileSystemCache.cacheLength", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("FileSystemCache.cacheStream", METADATA_TABLE), 6)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", TIMELINE), 2)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", LOG), 1)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
@@ -90,8 +86,6 @@ public class TestHudiMemoryCacheFileOperations
                         .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 2)
                         .addCopies(new FileOperation("FileSystemCache.cacheLength", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("FileSystemCache.cacheStream", METADATA_TABLE), 6)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", TIMELINE), 2)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", LOG), 1)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 4)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .add(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
@@ -113,8 +107,6 @@ public class TestHudiMemoryCacheFileOperations
                         .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 6)
                         .addCopies(new FileOperation("FileSystemCache.cacheLength", METADATA_TABLE), 39)
                         .addCopies(new FileOperation("FileSystemCache.cacheStream", METADATA_TABLE), 54)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", TIMELINE), 4)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", LOG), 2)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 39)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 5)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 3)
@@ -126,8 +118,6 @@ public class TestHudiMemoryCacheFileOperations
                         .addCopies(new FileOperation("FileSystemCache.cacheInput", DATA), 6)
                         .addCopies(new FileOperation("FileSystemCache.cacheLength", METADATA_TABLE), 29)
                         .addCopies(new FileOperation("FileSystemCache.cacheStream", METADATA_TABLE), 40)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", TIMELINE), 4)
-                        .addCopies(new FileOperation("FileSystemCache.cacheStream", LOG), 2)
                         .addCopies(new FileOperation("InputFile.lastModified", METADATA_TABLE), 29)
                         .addCopies(new FileOperation("InputFile.newStream", INDEX_DEFINITION), 4)
                         .addCopies(new FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 2)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiNoCacheFileOperations.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiNoCacheFileOperations.java
@@ -35,11 +35,9 @@ import static io.trino.filesystem.tracing.CacheFileSystemTraceUtils.isTrinoSchem
 import static io.trino.plugin.hudi.testing.ResourceHudiTablesInitializer.TestingTable.HUDI_MULTI_FG_PT_V8_MOR;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.DATA;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.INDEX_DEFINITION;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.LOG;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.METADATA_TABLE_PROPERTIES;
 import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TABLE_PROPERTIES;
-import static io.trino.plugin.hudi.util.FileOperationUtils.FileType.TIMELINE;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.stream.Collectors.toCollection;
 
@@ -78,8 +76,6 @@ public class TestHudiNoCacheFileOperations
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.length", METADATA_TABLE), 4)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE), 6)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TIMELINE), 2)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", LOG), 1)
                         .add(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
                         .build());
@@ -92,8 +88,6 @@ public class TestHudiNoCacheFileOperations
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.length", METADATA_TABLE), 4)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", INDEX_DEFINITION), 2)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE), 6)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TIMELINE), 2)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", LOG), 1)
                         .add(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES))
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TABLE_PROPERTIES), 2)
                         .build());
@@ -117,8 +111,6 @@ public class TestHudiNoCacheFileOperations
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE), 54)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 3)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TABLE_PROPERTIES), 5)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TIMELINE), 4)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", LOG), 2)
                         .build());
 
         assertFileSystemAccesses(query,
@@ -130,8 +122,6 @@ public class TestHudiNoCacheFileOperations
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE), 40)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", METADATA_TABLE_PROPERTIES), 2)
                         .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TABLE_PROPERTIES), 4)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", TIMELINE), 4)
-                        .addCopies(new FileOperationUtils.FileOperation("InputFile.newStream", LOG), 2)
                         .build());
     }
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSmokeTest.java
@@ -727,6 +727,7 @@ public class TestHudiSmokeTest
                 .withRecordLevelIndexEnabled(false)
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
+                .withResolveColumnNameCasingEnabled(true)
                 .build();
         MaterializedResult prunedRes = getQueryRunner().execute(session, "SELECT * FROM  " + table + " WHERE name='Alice'");
         MaterializedResult totalRes = getQueryRunner().execute(session, "SELECT * FROM " + table);
@@ -751,6 +752,7 @@ public class TestHudiSmokeTest
                 .withRecordIndexTimeout("1s")
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
+                .withResolveColumnNameCasingEnabled(true)
                 .build();
         MaterializedResult totalRes = getQueryRunner().execute(session, "SELECT * FROM " + HUDI_COW_TABLE_WITH_FIELD_NAMES_IN_CAPS);
         MaterializedResult prunedRes = getQueryRunner().execute(session, "SELECT * FROM  " + HUDI_COW_TABLE_WITH_FIELD_NAMES_IN_CAPS + " WHERE id='1'");
@@ -775,6 +777,7 @@ public class TestHudiSmokeTest
                 .withRecordIndexTimeout("1s")
                 .withSecondaryIndexEnabled(false)
                 .withPartitionStatsIndexEnabled(false)
+                .withResolveColumnNameCasingEnabled(true)
                 .build();
         MaterializedResult totalRes = getQueryRunner().execute(session, "SELECT * FROM " + HUDI_COW_TABLE_WITH_MULTI_KEYS_AND_FIELD_NAMES_IN_CAPS);
         MaterializedResult prunedRes = getQueryRunner().execute(session, "SELECT * FROM  " + HUDI_COW_TABLE_WITH_MULTI_KEYS_AND_FIELD_NAMES_IN_CAPS + " WHERE id='1' and age=30");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Disable column name case resolution by default.

Enabling this feature causes performance degradation because it requires reading the schema from Hudi table data files (and log files) to infer the table schema. 



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
