### PR TITLE
[ENG-38767] Load only required partitions for the table when partition filter is …

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -67,6 +67,7 @@ public class HudiConfig
     private Duration secondaryIndexWaitTimeout = new Duration(2, SECONDS);
     private boolean metadataCacheEnabled = true;
     private boolean metadataPartitionListingEnabled = true;
+    private boolean scopeFsvToPrunedPartitions;
 
     public List<String> getColumnsToHide()
     {
@@ -434,6 +435,20 @@ public class HudiConfig
     public HudiConfig setMetadataPartitionListingEnabled(boolean metadataPartitionListingEnabled)
     {
         this.metadataPartitionListingEnabled = metadataPartitionListingEnabled;
+        return this;
+    }
+
+    public boolean isScopeFsvToPrunedPartitions()
+    {
+        return scopeFsvToPrunedPartitions;
+    }
+
+    @Config("hudi.metadata.scope-fsv-to-pruned-partitions")
+    @ConfigDescription("Load only the pruned set of partitions into the file system view instead of all partitions. " +
+            "Reduces split generation latency for queries that touch a small fraction of partitions.")
+    public HudiConfig setScopeFsvToPrunedPartitions(boolean scopeFsvToPrunedPartitions)
+    {
+        this.scopeFsvToPrunedPartitions = scopeFsvToPrunedPartitions;
         return this;
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -75,6 +75,7 @@ public class HudiSessionProperties
     static final String RECORD_INDEX_WAIT_TIMEOUT = "record_index_wait_timeout";
     static final String SECONDARY_INDEX_WAIT_TIMEOUT = "secondary_index_wait_timeout";
     static final String METADATA_PARTITION_LISTING_ENABLED = "metadata_partition_listing_enabled";
+    static final String SCOPE_FSV_TO_PRUNED_PARTITIONS = "scope_fsv_to_pruned_partitions";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -247,6 +248,11 @@ public class HudiSessionProperties
                         hudiConfig.isMetadataPartitionListingEnabled(),
                         false),
                 booleanProperty(
+                        SCOPE_FSV_TO_PRUNED_PARTITIONS,
+                        "Load only pruned partitions into the Hudi file system view instead of all partitions",
+                        hudiConfig.isScopeFsvToPrunedPartitions(),
+                        false),
+                booleanProperty(
                         RESOLVE_COLUMN_NAME_CASING_ENABLED,
                         "Enable resolve column name casing",
                         hudiConfig.isResolveColumnNameCasingEnabled(),
@@ -413,5 +419,10 @@ public class HudiSessionProperties
     public static boolean isMetadataPartitionListingEnabled(ConnectorSession session)
     {
         return session.getProperty(METADATA_PARTITION_LISTING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isScopeFsvToPrunedPartitions(ConnectorSession session)
+    {
+        return session.getProperty(SCOPE_FSV_TO_PRUNED_PARTITIONS, Boolean.class);
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiDirectoryLister.java
@@ -17,10 +17,18 @@ import io.trino.plugin.hudi.partition.HudiPartitionInfo;
 import org.apache.hudi.common.model.FileSlice;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.stream.Stream;
 
 public interface HudiDirectoryLister
         extends Closeable
 {
     Stream<FileSlice> listStatus(HudiPartitionInfo partitionInfo, boolean useIndex);
+
+    /**
+     * Hint the lister with the set of partitions known to be relevant for this query so that
+     * the underlying file system view can be loaded for only those partitions instead of all.
+     * Must be called before the first {@link #listStatus} invocation. Default is a no-op.
+     */
+    default void setPrunedPartitionPaths(List<String> relativePartitionPaths) {}
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hudi.query;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.plugin.hudi.HudiTableHandle;
 import io.trino.plugin.hudi.partition.HudiPartitionInfo;
@@ -27,9 +28,11 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.util.Lazy;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static io.trino.plugin.hudi.HudiSessionProperties.isScopeFsvToPrunedPartitions;
 import static io.trino.plugin.hudi.HudiUtil.getFileSystemView;
 
 public class HudiSnapshotDirectoryLister
@@ -39,6 +42,8 @@ public class HudiSnapshotDirectoryLister
     private final HudiTableHandle tableHandle;
     private final Lazy<HoodieTableFileSystemView> lazyFileSystemView;
     private final Optional<HudiIndexSupport> indexSupportOpt;
+    private final boolean scopeFsvToPrunedPartitions;
+    private volatile List<String> prunedPartitionPaths;
 
     public HudiSnapshotDirectoryLister(
             ConnectorSession session,
@@ -47,21 +52,36 @@ public class HudiSnapshotDirectoryLister
             Lazy<HoodieTableMetadata> lazyTableMetadata)
     {
         this.tableHandle = tableHandle;
+        this.scopeFsvToPrunedPartitions = isScopeFsvToPrunedPartitions(session);
         SchemaTableName schemaTableName = tableHandle.getSchemaTableName();
         this.lazyFileSystemView = Lazy.lazily(() -> {
             HoodieTimer timer = HoodieTimer.start();
             HoodieTableMetaClient metaClient = tableHandle.getMetaClient();
             HoodieTableFileSystemView fileSystemView = getFileSystemView(lazyTableMetadata.get(), metaClient);
             if (enableMetadataTable) {
-                fileSystemView.loadAllPartitions();
+                List<String> scopedPaths = prunedPartitionPaths;
+                if (scopeFsvToPrunedPartitions && scopedPaths != null) {
+                    fileSystemView.loadPartitions(scopedPaths);
+                    log.info("Created file system view of table %s with %d pruned partitions in %s ms",
+                            schemaTableName, scopedPaths.size(), timer.endTimer());
+                }
+                else {
+                    fileSystemView.loadAllPartitions();
+                    log.info("Created file system view of table %s in %s ms", schemaTableName, timer.endTimer());
+                }
             }
-            log.info("Created file system view of table %s in %s ms", schemaTableName, timer.endTimer());
             return fileSystemView;
         });
 
         Lazy<HoodieTableMetaClient> lazyMetaClient = Lazy.lazily(tableHandle::getMetaClient);
         this.indexSupportOpt = enableMetadataTable ?
                 IndexSupportFactory.createIndexSupport(tableHandle, lazyMetaClient, lazyTableMetadata, tableHandle.getRegularPredicates(), session) : Optional.empty();
+    }
+
+    @Override
+    public void setPrunedPartitionPaths(List<String> relativePartitionPaths)
+    {
+        this.prunedPartitionPaths = ImmutableList.copyOf(relativePartitionPaths);
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -146,6 +146,13 @@ public class HudiBackgroundSplitLoader
             return;
         }
 
+        // Hint the directory lister with the pruned partition set so the underlying file system view
+        // can be loaded for only those partitions instead of all. The lister chooses whether to use
+        // this hint based on its own session-level flag; this call is always safe.
+        hudiDirectoryLister.setPrunedPartitionPaths(partitionQueue.stream()
+                .map(HiveHudiPartitionInfo::getRelativePartitionPath)
+                .toList());
+
         List<HudiPartitionInfoLoader> splitGenerators = new ArrayList<>();
         List<ListenableFuture<Void>> futures = new ArrayList<>();
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -59,6 +59,7 @@ public class TestHudiConfig
                 .setSecondaryIndexWaitTimeout(Duration.valueOf("2s"))
                 .setMetadataPartitionListingEnabled(true)
                 .setMetadataCacheEnabled(true)
+                .setScopeFsvToPrunedPartitions(false)
                 .setResolveColumnNameCasingEnabled(false));
     }
 
@@ -93,6 +94,7 @@ public class TestHudiConfig
                 .put("hudi.index.secondary-index.wait-timeout", "1s")
                 .put("hudi.metadata.cache.enabled", "false")
                 .put("hudi.metadata.partition-listing.enabled", "false")
+                .put("hudi.metadata.scope-fsv-to-pruned-partitions", "true")
                 .put("hudi.table.resolve-column-name-casing.enabled", "true")
                 .buildOrThrow();
 
@@ -124,6 +126,7 @@ public class TestHudiConfig
                 .setSecondaryIndexWaitTimeout(Duration.valueOf("1s"))
                 .setMetadataPartitionListingEnabled(false)
                 .setMetadataCacheEnabled(false)
+                .setScopeFsvToPrunedPartitions(true)
                 .setResolveColumnNameCasingEnabled(true);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Scope Hudi file system view loading to the set of pruned partitions instead of always loading every partition. When the Hudi metadata table is enabled, `HudiSnapshotDirectoryLister` previously called `HoodieTableFileSystemView.loadAllPartitions()` once per query, regardless of how many partitions actually matched the query predicate. For selective queries on tables with many partitions this dominates split-generation time.

This change introduces an opt-in session property `scope_fsv_to_pruned_partitions` (and matching config `hudi.metadata.scope-fsv-to-pruned-partitions`, default `false`) that switches the call to `loadPartitions(prunedPaths)`, where `prunedPaths` is the set of partitions that survived partition pruning in `HudiBackgroundSplitLoader`. Behavior is unchanged when the flag is off.

Mechanically:
- `HudiBackgroundSplitLoader.generateSplits` now publishes the pruned relative partition paths to the directory lister immediately after `getPartitionInfos()`, before any worker thread is submitted.
- `HudiSnapshotDirectoryLister` reads the session flag at construction and, if both the flag is enabled and pruned paths have been set when the lazy file system view initializes, calls `loadPartitions(...)` instead of `loadAllPartitions()`. If the paths have not been set for any reason, it falls back to the existing `loadAllPartitions()` behavior.
- `HudiDirectoryLister` gains a default no-op `setPrunedPartitionPaths(List<String>)` method, so the split loader can publish the paths without an `instanceof` check and without forcing other implementations to implement the hint.

The "Created file system view of table" log line now includes the pruned partition count when scoped loading is in effect, so the new path is easy to identify in the coordinator logs.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

In benchmarks against a Hudi 1.0 table with 365 partitions where the query predicate matched only 31 partitions, `loadAllPartitions()` accounted for roughly 85–90% of split-generation time (~5s on a 500k-row table, ~9s on a 1M-row table). The cost scales with total partition count and total file count in the metadata table `files` partition, not with the size of the pruned set, because the call eagerly materializes every partition's file slices through the metadata-backed file system view.

`HoodieTableFileSystemView.loadPartitions(List<String>)` is part of the public `TableFileSystemView` interface and is implemented by both `AbstractTableFileSystemView` and `RemoteHoodieTableFileSystemView`, so this change is portable across the file system view backends Hudi exposes.

The flag is intentionally off by default so existing deployments see no change. Once it has been validated in production-like workloads it can be promoted to the default. The non-metadata-table path (`hudi.metadata-enabled=false`) is untouched.

Other follow-ups that came out of the same investigation but are not part of this PR:
- Caching the file system view across queries keyed by `(table, latestCommitTime)` so repeat queries skip FSV creation entirely.
- Replacing `HoodieLocalEngineContext` with a parallel engine context so Hudi's internal `engineContext.parallelize(...)` calls in `loadPartitions` can actually parallelize HFile reads from the metadata table.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hudi connector
* Add `hudi.metadata.scope-fsv-to-pruned-partitions` configuration property and matching `scope_fsv_to_pruned_partitions` session property to load only pruned partitions into the Hudi file system view during split generation. Disabled by default. When enabled, this can substantially reduce split-generation latency for selective queries on tables with many partitions.