### PR TITLE
[ENG-38767] Scope Hudi column stats index lookups to pruned partitions

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -68,6 +68,7 @@ public class HudiConfig
     private boolean metadataCacheEnabled = true;
     private boolean metadataPartitionListingEnabled = true;
     private boolean scopeFsvToPrunedPartitions;
+    private boolean scopeColumnStatsToPrunedPartitions;
 
     public List<String> getColumnsToHide()
     {
@@ -449,6 +450,21 @@ public class HudiConfig
     public HudiConfig setScopeFsvToPrunedPartitions(boolean scopeFsvToPrunedPartitions)
     {
         this.scopeFsvToPrunedPartitions = scopeFsvToPrunedPartitions;
+        return this;
+    }
+
+    public boolean isScopeColumnStatsToPrunedPartitions()
+    {
+        return scopeColumnStatsToPrunedPartitions;
+    }
+
+    @Config("hudi.metadata.scope-column-stats-to-pruned-partitions")
+    @ConfigDescription("Restrict column stats index lookups to the pruned set of partitions. " +
+            "Defers the column stats fetch until partition pruning has run, then issues prefix " +
+            "lookups keyed by (column, partition) instead of column-only.")
+    public HudiConfig setScopeColumnStatsToPrunedPartitions(boolean scopeColumnStatsToPrunedPartitions)
+    {
+        this.scopeColumnStatsToPrunedPartitions = scopeColumnStatsToPrunedPartitions;
         return this;
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -76,6 +76,7 @@ public class HudiSessionProperties
     static final String SECONDARY_INDEX_WAIT_TIMEOUT = "secondary_index_wait_timeout";
     static final String METADATA_PARTITION_LISTING_ENABLED = "metadata_partition_listing_enabled";
     static final String SCOPE_FSV_TO_PRUNED_PARTITIONS = "scope_fsv_to_pruned_partitions";
+    static final String SCOPE_COLUMN_STATS_TO_PRUNED_PARTITIONS = "scope_column_stats_to_pruned_partitions";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -253,6 +254,11 @@ public class HudiSessionProperties
                         hudiConfig.isScopeFsvToPrunedPartitions(),
                         false),
                 booleanProperty(
+                        SCOPE_COLUMN_STATS_TO_PRUNED_PARTITIONS,
+                        "Restrict Hudi column stats index lookups to the pruned set of partitions",
+                        hudiConfig.isScopeColumnStatsToPrunedPartitions(),
+                        false),
+                booleanProperty(
                         RESOLVE_COLUMN_NAME_CASING_ENABLED,
                         "Enable resolve column name casing",
                         hudiConfig.isResolveColumnNameCasingEnabled(),
@@ -424,5 +430,10 @@ public class HudiSessionProperties
     public static boolean isScopeFsvToPrunedPartitions(ConnectorSession session)
     {
         return session.getProperty(SCOPE_FSV_TO_PRUNED_PARTITIONS, Boolean.class);
+    }
+
+    public static boolean isScopeColumnStatsToPrunedPartitions(ConnectorSession session)
+    {
+        return session.getProperty(SCOPE_COLUMN_STATS_TO_PRUNED_PARTITIONS, Boolean.class);
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiSnapshotDirectoryLister.java
@@ -81,7 +81,9 @@ public class HudiSnapshotDirectoryLister
     @Override
     public void setPrunedPartitionPaths(List<String> relativePartitionPaths)
     {
-        this.prunedPartitionPaths = ImmutableList.copyOf(relativePartitionPaths);
+        List<String> paths = ImmutableList.copyOf(relativePartitionPaths);
+        this.prunedPartitionPaths = paths;
+        indexSupportOpt.ifPresent(indexSupport -> indexSupport.setPrunedPartitionPaths(paths));
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiColumnStatsIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiColumnStatsIndexSupport.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.hudi.query.index;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -37,6 +39,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.util.Lazy;
@@ -51,8 +54,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.parquet.predicate.PredicateUtils.isStatisticsOverflow;
 import static io.trino.plugin.hudi.HudiSessionProperties.getColumnStatsWaitTimeout;
+import static io.trino.plugin.hudi.HudiSessionProperties.isScopeColumnStatsToPrunedPartitions;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -68,11 +74,16 @@ public class HudiColumnStatsIndexSupport
 {
     private static final Logger log = Logger.get(HudiColumnStatsIndexSupport.class);
     // file name -> column name -> domain with column stats
-    private final CompletableFuture<Optional<Map<String, Map<String, Domain>>>> domainsWithStatsFuture;
+    // volatile because the future may be created lazily from a different thread when scoped
+    // lookups are enabled (see setPrunedPartitionPaths).
+    private volatile CompletableFuture<Optional<Map<String, Map<String, Domain>>>> domainsWithStatsFuture;
     protected final TupleDomain<String> regularColumnPredicates;
     private final List<String> regularColumns;
+    private final Map<String, Type> columnTypes;
+    private final Lazy<HoodieTableMetadata> lazyTableMetadata;
     private final Duration columnStatsWaitTimeout;
-    private final long futureStartTimeMs;
+    private final boolean scopeColumnStatsToPrunedPartitions;
+    private volatile long futureStartTimeMs;
 
     public HudiColumnStatsIndexSupport(ConnectorSession session, SchemaTableName schemaTableName, Lazy<HoodieTableMetaClient> lazyMetaClient, Lazy<HoodieTableMetadata> lazyTableMetadata, TupleDomain<String> regularColumnPredicates)
     {
@@ -83,57 +94,117 @@ public class HudiColumnStatsIndexSupport
     {
         super(log, schemaTableName, lazyMetaClient);
         this.columnStatsWaitTimeout = getColumnStatsWaitTimeout(session);
+        this.scopeColumnStatsToPrunedPartitions = isScopeColumnStatsToPrunedPartitions(session);
         this.regularColumnPredicates = regularColumnPredicates;
         this.regularColumns = regularColumnPredicates.getDomains()
-                .map(domains -> new ArrayList<>(domains.keySet()))
-                .orElseGet(ArrayList::new);
+                .map(domains -> ImmutableList.copyOf(domains.keySet()))
+                .orElseGet(ImmutableList::of);
+        this.columnTypes = regularColumnPredicates.getDomains()
+                .map(domains -> domains.entrySet().stream()
+                        .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getType())))
+                .orElseGet(ImmutableMap::of);
+        this.lazyTableMetadata = lazyTableMetadata;
+
         if (regularColumnPredicates.isAll() || regularColumnPredicates.getDomains().isEmpty()) {
             this.domainsWithStatsFuture = CompletableFuture.completedFuture(Optional.empty());
+            this.futureStartTimeMs = System.currentTimeMillis();
+        }
+        else if (scopeColumnStatsToPrunedPartitions) {
+            // Defer the lookup until pruned partition paths are provided via
+            // setPrunedPartitionPaths(). shouldSkipFileSlice() falls back to no-skip if that
+            // never happens.
+            this.domainsWithStatsFuture = null;
+            this.futureStartTimeMs = 0L;
         }
         else {
-            // Get filter columns
-            List<String> encodedTargetColumnNames = regularColumns
-                    .stream()
-                    .map(col -> new ColumnIndexID(col).asBase64EncodedString()).collect(Collectors.toList());
-
-            Map<String, Type> columnTypes = regularColumnPredicates.getDomains().get().entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getType()));
-
-            domainsWithStatsFuture = CompletableFuture.supplyAsync(() -> {
-                HoodieTimer timer = HoodieTimer.start();
-                if (!lazyMetaClient.get().getTableConfig().getMetadataPartitions()
-                        .contains(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS)) {
-                    return Optional.empty();
-                }
-
-                Map<String, Map<String, Domain>> domainsWithStats =
-                        lazyTableMetadata.get().getRecordsByKeyPrefixes(encodedTargetColumnNames,
-                                        HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, true)
-                                .collectAsList()
-                                .stream()
-                                .filter(f -> f.getData().getColumnStatMetadata().isPresent())
-                                .map(f -> f.getData().getColumnStatMetadata().get())
-                                .collect(Collectors.groupingBy(
-                                        HoodieMetadataColumnStats::getFileName,
-                                        Collectors.toMap(
-                                                HoodieMetadataColumnStats::getColumnName,
-                                                // Pre-compute the Domain object for each HoodieMetadataColumnStats
-                                                stats -> getDomainFromColumnStats(stats.getColumnName(), columnTypes.get(stats.getColumnName()), stats))));
-
-                log.debug("Column stats lookup took %s ms and identified %d relevant file IDs.", timer.endTimer(), domainsWithStats.size());
-
-                return Optional.of(domainsWithStats);
-            });
+            // Existing behaviour: fire a column-only prefix lookup eagerly and let it run
+            // concurrently with file system view loading.
+            this.domainsWithStatsFuture = startLookup(buildColumnOnlyPrefixKeys());
+            this.futureStartTimeMs = System.currentTimeMillis();
         }
+    }
+
+    @Override
+    public void setPrunedPartitionPaths(List<String> relativePartitionPaths)
+    {
+        if (!scopeColumnStatsToPrunedPartitions || domainsWithStatsFuture != null) {
+            return;
+        }
+        if (regularColumnPredicates.isAll() || regularColumnPredicates.getDomains().isEmpty()) {
+            return;
+        }
+        List<String> rawKeys = buildColumnPartitionPrefixKeys(relativePartitionPaths);
         this.futureStartTimeMs = System.currentTimeMillis();
+        this.domainsWithStatsFuture = startLookup(rawKeys);
+    }
+
+    private List<String> buildColumnOnlyPrefixKeys()
+    {
+        return regularColumns.stream()
+                .map(col -> new ColumnIndexID(col).asBase64EncodedString())
+                .collect(toImmutableList());
+    }
+
+    @VisibleForTesting
+    List<String> buildColumnPartitionPrefixKeys(List<String> relativePartitionPaths)
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (String column : regularColumns) {
+            String columnPart = new ColumnIndexID(column).asBase64EncodedString();
+            for (String partition : relativePartitionPaths) {
+                String partitionPart = new PartitionIndexID(
+                        HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier(partition))
+                        .asBase64EncodedString();
+                builder.add(columnPart + partitionPart);
+            }
+        }
+        return builder.build();
+    }
+
+    private CompletableFuture<Optional<Map<String, Map<String, Domain>>>> startLookup(List<String> rawKeys)
+    {
+        if (rawKeys.isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            HoodieTimer timer = HoodieTimer.start();
+            if (!lazyMetaClient.get().getTableConfig().getMetadataPartitions()
+                    .contains(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS)) {
+                return Optional.empty();
+            }
+
+            Map<String, Map<String, Domain>> domainsWithStats =
+                    lazyTableMetadata.get().getRecordsByKeyPrefixes(rawKeys,
+                                    HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, true)
+                            .collectAsList()
+                            .stream()
+                            .filter(f -> f.getData().getColumnStatMetadata().isPresent())
+                            .map(f -> f.getData().getColumnStatMetadata().get())
+                            .collect(Collectors.groupingBy(
+                                    HoodieMetadataColumnStats::getFileName,
+                                    Collectors.toMap(
+                                            HoodieMetadataColumnStats::getColumnName,
+                                            stats -> getDomainFromColumnStats(stats.getColumnName(), columnTypes.get(stats.getColumnName()), stats))));
+
+            log.debug("Column stats lookup took %s ms over %d prefix keys and identified %d relevant file IDs.",
+                    timer.endTimer(), rawKeys.size(), domainsWithStats.size());
+
+            return Optional.of(domainsWithStats);
+        });
     }
 
     @Override
     public boolean shouldSkipFileSlice(FileSlice slice)
     {
+        CompletableFuture<Optional<Map<String, Map<String, Domain>>>> future = domainsWithStatsFuture;
+        if (future == null) {
+            // Scoped lookup was enabled but pruned partition paths were never published.
+            // Fall back to no-skip rather than blocking forever or throwing.
+            return false;
+        }
         try {
-            if (domainsWithStatsFuture.isDone()) {
-                Optional<Map<String, Map<String, Domain>>> domainsWithStatsOpt = domainsWithStatsFuture.get();
+            if (future.isDone()) {
+                Optional<Map<String, Map<String, Domain>>> domainsWithStatsOpt = future.get();
                 return domainsWithStatsOpt
                         .map(domainsWithStats -> shouldSkipFileSlice(slice, domainsWithStats, regularColumnPredicates, regularColumns))
                         .orElse(false);
@@ -148,7 +219,7 @@ public class HudiColumnStatsIndexSupport
             // If still within the timeout window, wait up to the remaining time
             long remainingMs = Math.max(0, columnStatsWaitTimeout.toMillis() - elapsedMs);
             Optional<Map<String, Map<String, Domain>>> statsOpt =
-                    domainsWithStatsFuture.get(remainingMs, TimeUnit.MILLISECONDS);
+                    future.get(remainingMs, TimeUnit.MILLISECONDS);
 
             return statsOpt
                     .map(stats -> shouldSkipFileSlice(slice, stats, regularColumnPredicates, regularColumns))
@@ -213,7 +284,7 @@ public class HudiColumnStatsIndexSupport
         }
 
         // if any log or base file in the file slice matches the predicate, all files in the file slice needs to be read
-        return filesToLookUp.stream().allMatch(fileName -> {
+        boolean skip = filesToLookUp.stream().allMatch(fileName -> {
             // If no stats exist for this specific file, we cannot prune it.
             if (!domainsWithStats.containsKey(fileName)) {
                 return false;
@@ -221,6 +292,9 @@ public class HudiColumnStatsIndexSupport
             Map<String, Domain> fileDomainsWithStats = domainsWithStats.get(fileName);
             return !evaluateStatisticPredicate(regularColumnPredicates, fileDomainsWithStats, regularColumns);
         });
+        String fileName = fileSlice.getBaseFile().map(BaseFile::getFileName).orElse("<no-base-file>");
+        log.debug("File slice [%s] %s by column stats index", fileName, skip ? "skipped" : "processed");
+        return skip;
     }
 
     protected static boolean evaluateStatisticPredicate(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiIndexSupport.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/index/HudiIndexSupport.java
@@ -16,6 +16,8 @@ package io.trino.plugin.hudi.query.index;
 import io.trino.spi.predicate.TupleDomain;
 import org.apache.hudi.common.model.FileSlice;
 
+import java.util.List;
+
 public interface HudiIndexSupport
 {
     boolean canApply(TupleDomain<String> tupleDomain);
@@ -24,4 +26,12 @@ public interface HudiIndexSupport
     {
         return false;
     }
+
+    /**
+     * Hint the index implementation with the set of partitions known to be relevant for the query
+     * after partition pruning. Implementations may use this to scope index lookups to those
+     * partitions instead of the whole table. Must be called before any {@link #shouldSkipFileSlice}
+     * invocation. Default is a no-op.
+     */
+    default void setPrunedPartitionPaths(List<String> relativePartitionPaths) {}
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -60,6 +60,7 @@ public class TestHudiConfig
                 .setMetadataPartitionListingEnabled(true)
                 .setMetadataCacheEnabled(true)
                 .setScopeFsvToPrunedPartitions(false)
+                .setScopeColumnStatsToPrunedPartitions(false)
                 .setResolveColumnNameCasingEnabled(false));
     }
 
@@ -95,6 +96,7 @@ public class TestHudiConfig
                 .put("hudi.metadata.cache.enabled", "false")
                 .put("hudi.metadata.partition-listing.enabled", "false")
                 .put("hudi.metadata.scope-fsv-to-pruned-partitions", "true")
+                .put("hudi.metadata.scope-column-stats-to-pruned-partitions", "true")
                 .put("hudi.table.resolve-column-name-casing.enabled", "true")
                 .buildOrThrow();
 
@@ -127,6 +129,7 @@ public class TestHudiConfig
                 .setMetadataPartitionListingEnabled(false)
                 .setMetadataCacheEnabled(false)
                 .setScopeFsvToPrunedPartitions(true)
+                .setScopeColumnStatsToPrunedPartitions(true)
                 .setResolveColumnNameCasingEnabled(true);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/query/index/TestHudiColumnStatsIndexSupport.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/query/index/TestHudiColumnStatsIndexSupport.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi.query.index;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.plugin.hudi.HudiConfig;
+import io.trino.plugin.hudi.HudiSessionProperties;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.testing.TestingConnectorSession;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.util.Lazy;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.spi.predicate.Domain.singleValue;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHudiColumnStatsIndexSupport
+{
+    private static final SchemaTableName SCHEMA_TABLE = new SchemaTableName("schema", "table");
+
+    @Test
+    public void testScopedFlagOnFallsBackWhenPrunedPathsNotPublished()
+    {
+        // With the scoped flag on, the constructor does not start the lookup; it waits for
+        // setPrunedPartitionPaths to publish the pruned set. If that never happens (e.g. the
+        // caller forgot to wire it up), shouldSkipFileSlice must fall back to "no skip"
+        // rather than block forever or throw.
+        HudiColumnStatsIndexSupport support = new HudiColumnStatsIndexSupport(
+                sessionWithScopeFlag(true),
+                SCHEMA_TABLE,
+                failingMetaClient(),
+                failingMetadata(),
+                singleColumnPredicate());
+
+        assertThat(support.shouldSkipFileSlice(newFileSlice())).isFalse();
+    }
+
+    @Test
+    public void testBuildColumnPartitionPrefixKeysCombinesColumnAndPartitionIds()
+    {
+        HudiColumnStatsIndexSupport support = new HudiColumnStatsIndexSupport(
+                sessionWithScopeFlag(true),
+                SCHEMA_TABLE,
+                failingMetaClient(),
+                failingMetadata(),
+                singleColumnPredicate());
+
+        List<String> partitions = ImmutableList.of("year=2024", "year=2025");
+        List<String> rawKeys = support.buildColumnPartitionPrefixKeys(partitions);
+
+        String columnPart = new ColumnIndexID("col1").asBase64EncodedString();
+        String expected2024 = columnPart + new PartitionIndexID(
+                HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier("year=2024")).asBase64EncodedString();
+        String expected2025 = columnPart + new PartitionIndexID(
+                HoodieTableMetadataUtil.getColumnStatsIndexPartitionIdentifier("year=2025")).asBase64EncodedString();
+        assertThat(rawKeys).containsExactly(expected2024, expected2025);
+    }
+
+    @Test
+    public void testNoPredicatesShortCircuitsWithoutMetadataAccess()
+    {
+        // With no regular column predicates, the constructor publishes a completed empty
+        // future regardless of the flag. shouldSkipFileSlice must never skip, and must not
+        // touch the table metadata.
+        HudiColumnStatsIndexSupport support = new HudiColumnStatsIndexSupport(
+                sessionWithScopeFlag(true),
+                SCHEMA_TABLE,
+                failingMetaClient(),
+                failingMetadata(),
+                TupleDomain.all());
+
+        assertThat(support.shouldSkipFileSlice(newFileSlice())).isFalse();
+    }
+
+    @Test
+    public void testFlagOffSetPrunedPartitionPathsIsNoOp()
+    {
+        // With the flag off, setPrunedPartitionPaths must not kick off a deferred lookup.
+        // Combined with TupleDomain.all() (constructor sets a completed empty future), this
+        // guarantees no metadata access regardless of whether pruned paths are published.
+        HudiColumnStatsIndexSupport support = new HudiColumnStatsIndexSupport(
+                sessionWithScopeFlag(false),
+                SCHEMA_TABLE,
+                failingMetaClient(),
+                failingMetadata(),
+                TupleDomain.all());
+
+        support.setPrunedPartitionPaths(ImmutableList.of("year=2024"));
+        assertThat(support.shouldSkipFileSlice(newFileSlice())).isFalse();
+    }
+
+    private static ConnectorSession sessionWithScopeFlag(boolean scopeToPrunedPartitions)
+    {
+        HudiConfig config = new HudiConfig().setScopeColumnStatsToPrunedPartitions(scopeToPrunedPartitions);
+        HudiSessionProperties sessionProperties = new HudiSessionProperties(config, new ParquetReaderConfig());
+        return TestingConnectorSession.builder()
+                .setPropertyMetadata(sessionProperties.getSessionProperties())
+                .build();
+    }
+
+    private static Lazy<HoodieTableMetaClient> failingMetaClient()
+    {
+        return Lazy.lazily(() -> { throw new AssertionError("metaClient must not be accessed"); });
+    }
+
+    private static Lazy<HoodieTableMetadata> failingMetadata()
+    {
+        return Lazy.lazily(() -> { throw new AssertionError("tableMetadata must not be accessed"); });
+    }
+
+    private static TupleDomain<String> singleColumnPredicate()
+    {
+        return TupleDomain.withColumnDomains(ImmutableMap.of("col1", singleValue(BIGINT, 42L)));
+    }
+
+    private static FileSlice newFileSlice()
+    {
+        return new FileSlice("partition", "0", "file-1");
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in flag that defers the Hudi column stats metadata read until *after* partition pruning has run, then scopes the metadata table lookup to the pruned set of partitions instead of scanning column stats across the entire table.

- New config: `hudi.metadata.scope-column-stats-to-pruned-partitions` (session: `scope_column_stats_to_pruned_partitions`). Default `false`, so existing behaviour is unchanged.
- When enabled, `HudiColumnStatsIndexSupport` does **not** kick off the column-only prefix lookup eagerly. Instead it waits for `HudiSnapshotDirectoryLister` to publish the pruned partition paths via the new `HudiIndexSupport.setPrunedPartitionPaths(...)` hook, then issues a `(column, partition)` prefix lookup keyed by both `ColumnIndexID` and `PartitionIndexID`.
- If the pruned paths never arrive, `shouldSkipFileSlice` falls back to "no skip" rather than blocking forever — the worst case is the same as having column stats disabled for that query, not a hang.
- Existing path (flag off) is unchanged: still a column-only prefix lookup started in the constructor and run concurrently with FSV loading.

## Why

For wide tables with many partitions and a selective partition filter, the previous column-only prefix lookup pays for column stats across the whole table even though we only need stats for the partitions that survive pruning. Scoping the lookup to those partitions trades a small bit of pipelining (we can no longer overlap stats fetch with FSV load) for a much smaller metadata scan. The flag is off by default precisely because that pipelining tradeoff makes the win workload-dependent.

## Stacking

This PR is stacked on #76. The base is `hudi-scope-fsv-to-pruned-partitions`; GitHub will retarget to `master` once #76 merges. The diff against the base is the column-stats change only.

## Implementation notes

- `HudiIndexSupport` gets a `default` no-op `setPrunedPartitionPaths(...)` so other index implementations are unaffected.
- `HudiSnapshotDirectoryLister` now forwards the pruned partition paths it already receives to its `indexSupportOpt`.
- `domainsWithStatsFuture` and `futureStartTimeMs` are now `volatile` because in scoped mode the future is constructed lazily from the directory-listing thread, not the constructor.

## Test plan

- [ ] `TestHudiConfig` (covers defaults + explicit flag mapping for the new property)
- [ ] Run a query with a selective partition filter against a column-stats-indexed table with the flag on, confirm column stats still skip non-matching file slices
- [ ] Run the same query with the flag off, confirm behaviour is identical to before this change
- [ ] Confirm that disabling/not publishing pruned partitions (e.g. unpartitioned table or pruning failure) does not hang the query